### PR TITLE
fix seperateCurrency & currencySeperator

### DIFF
--- a/Classes/ViewHelpers/Format/CurrencyViewHelper.php
+++ b/Classes/ViewHelpers/Format/CurrencyViewHelper.php
@@ -98,7 +98,7 @@ class CurrencyViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHe
         }
         $output = number_format($floatToFormat, $decimals, $decimalSeparator, $thousandsSeparator);
         if ($currencySign !== '') {
-            $currencySeparator = $separateCurrency ? ' ' : '';
+            $currencySeparator = $separateCurrency ? '&nbsp;' : '';
             if ($prependCurrency === true) {
                 $output = $currencySign . $currencySeparator . $output;
             } else {

--- a/ext_typoscript_constants.txt
+++ b/ext_typoscript_constants.txt
@@ -14,7 +14,7 @@ plugin.tx_cart {
             decimalSeparator   = ,
             thousandsSeparator = .
             prependCurrency    = 0
-            separateCurrency   = &nbsp;
+            separateCurrency   = 1
             decimals           = 2
         }
     }


### PR DESCRIPTION
the typoscript suggested a seperator and the implementation check as a boolean. I made it a boolean with the only logical seperator &nbsp; Not space because currency symbol should always be on the same line.
