### PR TITLE
Require only the Core package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "typo3/cms": "^7.6 || ^8.7"
+        "typo3/cms-core": "^7.6.0 || ^8.7.0"
     },
     "require-dev": {
         "nimut/testing-framework": "^1.0",


### PR DESCRIPTION
This makes it easier to use the extension in non standard installations.