### PR TITLE
[BUGFIX] Issue #321

### DIFF
--- a/Classes/Controller/Cart/CouponController.php
+++ b/Classes/Controller/Cart/CouponController.php
@@ -10,6 +10,7 @@ namespace Extcode\Cart\Controller\Cart;
  */
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 class CouponController extends ActionController
 {
@@ -55,9 +56,9 @@ class CouponController extends ActionController
 
                 if ($couponWasAdded == 1) {
                     $this->addFlashMessage(
-                        \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+                        LocalizationUtility::translate(
                             'tx_cart.ok.coupon.added',
-                            $this->extensionName
+                            'Cart'
                         ),
                         '',
                         \TYPO3\CMS\Core\Messaging\AbstractMessage::OK,
@@ -66,9 +67,9 @@ class CouponController extends ActionController
                 }
                 if ($couponWasAdded == -1) {
                     $this->addFlashMessage(
-                        \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+                        LocalizationUtility::translate(
                             'tx_cart.error.coupon.already_added',
-                            $this->extensionName
+                            'Cart'
                         ),
                         '',
                         \TYPO3\CMS\Core\Messaging\AbstractMessage::WARNING,
@@ -77,9 +78,9 @@ class CouponController extends ActionController
                 }
                 if ($couponWasAdded == -2) {
                     $this->addFlashMessage(
-                        \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+                        LocalizationUtility::translate(
                             'tx_cart.error.coupon.not_combinable',
-                            $this->extensionName
+                            'Cart'
                         ),
                         '',
                         \TYPO3\CMS\Core\Messaging\AbstractMessage::WARNING,
@@ -88,9 +89,9 @@ class CouponController extends ActionController
                 }
             } else {
                 $this->addFlashMessage(
-                    \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+                    LocalizationUtility::translate(
                         'tx_cart.error.coupon.not_accepted',
-                        $this->extensionName
+                        'Cart'
                     ),
                     '',
                     \TYPO3\CMS\Core\Messaging\AbstractMessage::WARNING,
@@ -116,9 +117,9 @@ class CouponController extends ActionController
 
             if ($couponWasRemoved == 1) {
                 $this->addFlashMessage(
-                    \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+                    LocalizationUtility::translate(
                         'tx_cart.ok.coupon.removed',
-                        $this->extensionName
+                        'Cart'
                     ),
                     '',
                     \TYPO3\CMS\Core\Messaging\AbstractMessage::OK,
@@ -127,9 +128,9 @@ class CouponController extends ActionController
             }
             if ($couponWasRemoved == -1) {
                 $this->addFlashMessage(
-                    \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+                    LocalizationUtility::translate(
                         'tx_cart.error.coupon.not_found',
-                        $this->extensionName
+                        'Cart'
                     ),
                     '',
                     \TYPO3\CMS\Core\Messaging\AbstractMessage::WARNING,

--- a/Classes/Controller/Cart/OrderController.php
+++ b/Classes/Controller/Cart/OrderController.php
@@ -14,6 +14,7 @@ use Extcode\Cart\Event\ProcessOrderCreateEvent;
 use Extcode\Cart\Event\ProcessOrderCreateEventInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 class OrderController extends ActionController
 {
@@ -24,7 +25,7 @@ class OrderController extends ActionController
 
     protected function getErrorFlashMessage()
     {
-        $errorMsg = \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+        $errorMsg = LocalizationUtility::translate(
             'tx_cart.error.validation',
             'Cart'
         );

--- a/Classes/Controller/Cart/PaymentController.php
+++ b/Classes/Controller/Cart/PaymentController.php
@@ -9,6 +9,8 @@ namespace Extcode\Cart\Controller\Cart;
  * LICENSE file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
 class PaymentController extends ActionController
 {
     const AJAX_CART_TYPE_NUM = '2278001';
@@ -31,9 +33,9 @@ class PaymentController extends ActionController
                 $this->cart->setPayment($payment);
             } else {
                 $this->addFlashMessage(
-                    \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+                    LocalizationUtility::translate(
                         'tx_cart.controller.cart.action.set_payment.not_available',
-                        $this->extensionName
+                        'Cart'
                     ),
                     '',
                     \TYPO3\CMS\Core\Messaging\AbstractMessage::ERROR,

--- a/Classes/Controller/Cart/ProductController.php
+++ b/Classes/Controller/Cart/ProductController.php
@@ -12,6 +12,7 @@ namespace Extcode\Cart\Controller\Cart;
 use Extcode\Cart\Event\CheckProductAvailabilityEvent;
 use Extcode\Cart\Event\RetrieveProductsFromRequestEvent;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 class ProductController extends ActionController
 {
@@ -107,7 +108,7 @@ class ProductController extends ActionController
 
         $this->sessionHandler->write($this->cart, $this->settings['cart']['pid']);
 
-        $messageBody = \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+        $messageBody = LocalizationUtility::translate(
             'tx_cart.success.stock_handling.add.' . ($quantity == 1 ? 'one' : 'more'),
             'cart',
             [$quantity]

--- a/Classes/Controller/Cart/ShippingController.php
+++ b/Classes/Controller/Cart/ShippingController.php
@@ -9,6 +9,8 @@ namespace Extcode\Cart\Controller\Cart;
  * LICENSE file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
 class ShippingController extends ActionController
 {
     const AJAX_CART_TYPE_NUM = '2278001';
@@ -31,9 +33,9 @@ class ShippingController extends ActionController
                 $this->cart->setShipping($shipping);
             } else {
                 $this->addFlashMessage(
-                    \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+                    LocalizationUtility::translate(
                         'tx_cart.controller.cart.action.set_shipping.not_available',
-                        $this->extensionName
+                        'Cart'
                     ),
                     '',
                     \TYPO3\CMS\Core\Messaging\AbstractMessage::ERROR,

--- a/Classes/ViewHelpers/Form/SelectViewHelper.php
+++ b/Classes/ViewHelpers/Form/SelectViewHelper.php
@@ -9,6 +9,8 @@ namespace Extcode\Cart\ViewHelpers\Form;
  * LICENSE file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
 class SelectViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\SelectViewHelper
 {
     public function initializeArguments()
@@ -74,7 +76,7 @@ class SelectViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\SelectViewHelpe
         $key = $this->arguments['translationKey'];
 
         if ($key != null) {
-            $output = \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+            $output = LocalizationUtility::translate(
                 $key . '.' . htmlspecialchars($value),
                 'Cart'
             );


### PR DESCRIPTION
$extensionName is deprecated sinceTYPO3v10.

I fixed the described error and replaced the $extensionName with 'Cart' and tested this already in my development environment.

To avoid further errors I have also corrected all $extensionName associated with LocalizationUtility::translate