### PR TITLE
[BUGFIX] Use int keys for MAIL templateRootPaths

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -122,8 +122,8 @@ if (TYPO3_MODE === 'FE') {
 }
 
 // view paths for TYPO3 Mail API
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['templateRootPaths']['1588829280'] = 'EXT:cart/Resources/Private/Templates/';
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['partialRootPaths']['1588829280'] = 'EXT:cart/Resources/Private/Partials/';
+$GLOBALS['TYPO3_CONF_VARS']['MAIL']['templateRootPaths'][1588829280] = 'EXT:cart/Resources/Private/Templates/';
+$GLOBALS['TYPO3_CONF_VARS']['MAIL']['partialRootPaths'][1588829280] = 'EXT:cart/Resources/Private/Partials/';
 
 // view paths for TYPO3 Dashboard
 call_user_func(static function () {


### PR DESCRIPTION
Using string keys for `templateRootPaths` destroys path sorting as this is only done for integer indexed arrays.

See https://github.com/TYPO3/typo3/blob/main/typo3/sysext/fluid/Classes/View/TemplatePaths.php#L101