### PR TITLE
Avoid PHP 8 warning, if `settings.cart.steps` is not set

### DIFF
--- a/Classes/Controller/Cart/CartController.php
+++ b/Classes/Controller/Cart/CartController.php
@@ -28,7 +28,7 @@ class CartController extends ActionController
             return;
         }
 
-        $steps = (int)$this->settings['cart']['steps'];
+        $steps = (int)($this->settings['cart']['steps'] ?? 0);
         if ($steps > 1) {
             if ($this->request->hasArgument('step')) {
                 $currentStep = (int)$this->request->getArgument('step') ?: 1;


### PR DESCRIPTION
If the TypoScript property `settings.cart.steps` is not set, a PHP warning is thrown.