### PR TITLE
[BUGFIX] Use correct array path to country payment settings

### DIFF
--- a/Classes/EventListener/Order/Finish/Email.php
+++ b/Classes/EventListener/Order/Finish/Email.php
@@ -30,7 +30,7 @@ class Email
         $paymentId = $orderItem->getPayment()->getServiceId();
 
         if ($paymentCountry) {
-            $serviceSettings = $settings['payments'][$paymentCountry]['options'][$paymentId];
+            $serviceSettings = $settings['payments']['countries'][$paymentCountry]['options'][$paymentId];
         } else {
             $serviceSettings = $settings['payments']['options'][$paymentId];
         }


### PR DESCRIPTION
It's either too late to day ... or the array path in `Finish/Email.php` does not match the typoscript path.