### PR TITLE
[Bugfix] Add all form fields to validation setup

### DIFF
--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -93,31 +93,39 @@ plugin.tx_cart {
             billingAddress {
                 fields {
                     salutation.validator = NotEmpty
+                    title.validator = Empty
                     firstName.validator = NotEmpty
                     lastName.validator = NotEmpty
                     email.validator = NotEmpty
                     phone.validator = Empty
                     fax.validator = Empty
+                    company.validator = Empty
+                    taxIdentificationNumber.validator = Empty
                     street.validator = NotEmpty
                     streetNumber.validator = Empty
                     addition.validator = Empty
                     zip.validator = NotEmpty
                     city.validator = NotEmpty
+                    country.validator = NotEmpty
                 }
             }
             shippingAddress {
                 fields {
                     salutation.validator = NotEmpty
+                    title.validator = Empty
                     firstName.validator = NotEmpty
                     lastName.validator = NotEmpty
                     email.validator = NotEmpty
                     phone.validator = Empty
                     fax.validator = Empty
+                    company.validator = Empty
+                    taxIdentificationNumber.validator = Empty
                     street.validator = NotEmpty
                     streetNumber.validator = Empty
                     addition.validator = Empty
                     zip.validator = NotEmpty
                     city.validator = NotEmpty
+                    country.validator = NotEmpty
                 }
             }
         }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -165,6 +165,9 @@ plugin.tx_cart {
                     salutation {
                         validator = {$plugin.tx_cart.settings.validation.billingAddress.fields.salutation.validator}
                     }
+                    title {
+                        validator = {$plugin.tx_cart.settings.validation.billingAddress.fields.title.validator}
+                    }
                     firstName {
                         validator = {$plugin.tx_cart.settings.validation.billingAddress.fields.firstName.validator}
                     }
@@ -179,6 +182,12 @@ plugin.tx_cart {
                     }
                     fax {
                         validator = {$plugin.tx_cart.settings.validation.billingAddress.fields.fax.validator}
+                    }
+                    company {
+                        validator = {$plugin.tx_cart.settings.validation.billingAddress.fields.company.validator}
+                    }
+                    taxIdentificationNumber {
+                        validator = {$plugin.tx_cart.settings.validation.billingAddress.fields.taxIdentificationNumber.validator}
                     }
                     street {
                         validator = {$plugin.tx_cart.settings.validation.billingAddress.fields.street.validator}
@@ -195,12 +204,18 @@ plugin.tx_cart {
                     city {
                         validator = {$plugin.tx_cart.settings.validation.billingAddress.fields.city.validator}
                     }
+                    country {
+                        validator = {$plugin.tx_cart.settings.validation.billingAddress.fields.country.validator}
+                    }
                 }
             }
             shippingAddress {
                 fields {
                     salutation {
                         validator = {$plugin.tx_cart.settings.validation.shippingAddress.fields.salutation.validator}
+                    }
+                    title {
+                        validator = {$plugin.tx_cart.settings.validation.shippingAddress.fields.title.validator}
                     }
                     firstName {
                         validator = {$plugin.tx_cart.settings.validation.shippingAddress.fields.firstName.validator}
@@ -217,6 +232,12 @@ plugin.tx_cart {
                     fax {
                         validator = {$plugin.tx_cart.settings.validation.shippingAddress.fields.fax.validator}
                     }
+                    company {
+                        validator = {$plugin.tx_cart.settings.validation.shippingAddress.fields.company.validator}
+                    }
+                    taxIdentificationNumber {
+                        validator = {$plugin.tx_cart.settings.validation.shippingAddress.fields.taxIdentificationNumber.validator}
+                    }
                     street {
                         validator = {$plugin.tx_cart.settings.validation.shippingAddress.fields.street.validator}
                     }
@@ -231,6 +252,9 @@ plugin.tx_cart {
                     }
                     city {
                         validator = {$plugin.tx_cart.settings.validation.shippingAddress.fields.city.validator}
+                    }
+                    country {
+                        validator = {$plugin.tx_cart.settings.validation.shippingAddress.fields.country.validator}
                     }
                 }
             }

--- a/Documentation/Administrator/Configuration/Cart/ValidatingAndHidingFields/Index.rst
+++ b/Documentation/Administrator/Configuration/Cart/ValidatingAndHidingFields/Index.rst
@@ -6,11 +6,19 @@
 Validating and hiding fields
 ============================
 
-Using this TypoScript configuration it is possible to change the validation and
-rendering of fields of the billing and shipping address.
-
+Using the below shown TypoScript configuration allows to change the validation
+and rendering of fields of the billing and shipping address.
 The partials for the display of the addresses evaluates this configuration.
-It controls whether the fields are mandatory, optional or not rendered att all.
+It controls whether the fields are mandatory, optional or not rendered at all.
+
+.. TIP::
+   This way it is easily possible to unhide e.g the fields `streetNumber` or
+   `addition` (which is a field for additional address information) which are
+   already defined but hidden by default.
+
+   Have a look at all fields with the value `Empty` to see all available
+   fields.
+
 
 .. code-block:: typoscript
    :caption: EXT:cart/Configuration/TypoScript/setup.typoscript
@@ -21,31 +29,39 @@ It controls whether the fields are mandatory, optional or not rendered att all.
                billingAddress {
                    fields {
                        salutation.validator = NotEmpty
+                       title.validator = Empty
                        firstName.validator = NotEmpty
                        lastName.validator = NotEmpty
                        email.validator = NotEmpty
                        phone.validator = Empty
                        fax.validator = Empty
+                       company.validator = Empty
+                       taxIdentificationNumber.validator = Empty
                        street.validator = NotEmpty
                        streetNumber.validator = Empty
                        addition.validator = Empty
                        zip.validator = NotEmpty
                        city.validator = NotEmpty
+                       country.validator = NotEmpty
                    }
                }
                shippingAddress {
                    fields {
                        salutation.validator = NotEmpty
+                       title.validator = Empty
                        firstName.validator = NotEmpty
                        lastName.validator = NotEmpty
                        email.validator = NotEmpty
                        phone.validator = Empty
                        fax.validator = Empty
+                       company.validator = Empty
+                       taxIdentificationNumber.validator = Empty
                        street.validator = NotEmpty
                        streetNumber.validator = Empty
                        addition.validator = Empty
                        zip.validator = NotEmpty
                        city.validator = NotEmpty
+                       country.validator = NotEmpty
                    }
                }
            }
@@ -68,6 +84,7 @@ Option `Not Empty`
 * The input field is rendered with the attribute `required` set to `true`.
 
 .. code-block:: typoscript
+   :caption: EXT:sitepackage/Configuration/TypoScript/constants.typoscript
 
    plugin.tx_cart.settings.validation.billingAddress.fields {
        salutation.validator = NotEmpty
@@ -82,6 +99,7 @@ Option `Empty`
 * The server checks whether the field is empty.
 
 .. code-block:: typoscript
+   :caption: EXT:sitepackage/Configuration/TypoScript/constants.typoscript
 
    plugin.tx_cart.settings.validation.billingAddress.fields {
        salutation.validator = Empty
@@ -96,7 +114,12 @@ This has the following consequences:
 * The label of the field is rendered without a trailing "*".
 * The input field is rendered without the attribute `required`.
 
+.. IMPORTANT::
+   While the two configuration above can be made within the
+   `constants.typoscript` is this configuration done in `setup.typoscript`.
+
 .. code-block:: typoscript
+   :caption: EXT:sitepackage/Configuration/TypoScript/setup.typoscript
 
    plugin.tx_cart.settings.validation.billingAddress.fields {
        # !!! It is necessary to remove the whole address field,

--- a/Documentation/Changelog/9.0/Breaking-445-Include-all-address-fields-in-validation.rst
+++ b/Documentation/Changelog/9.0/Breaking-445-Include-all-address-fields-in-validation.rst
@@ -1,0 +1,30 @@
+.. include:: ../../Includes.txt
+
+=========================================================
+Breaking: #445 - Include all address fields in validation
+=========================================================
+
+See :issue:`445`
+
+Description
+===========
+
+All fields which exists for the billing address and for the shipping address
+are now included within the validation array in TypoScript. The fields
+`title`, `company`, `taxIdentificationNumber` and `country` were not included.
+Including those fields makes it easier and especially more logic to manage
+the validation and visibility of those fields.
+
+Affected Installations
+======================
+
+By default the fields `title`, `company` and `taxIdentificationNumber` will
+not be rendered, the field country will be rendered and required.
+
+Migration
+=========
+
+See :ref:`validating-and-hiding-fields` how to manage the visibility and
+validation of address fields.
+
+.. index:: Template, Frontend, TypoScript


### PR DESCRIPTION
All existing input fields of billing address and
shipping address are now included in the validator setup which influences the rendering of the
corresponding fields.

Solves #383, #445