### PR TITLE
[TASK] Add tax identification number to emails

### DIFF
--- a/Resources/Private/Partials/Mail/Address.html
+++ b/Resources/Private/Partials/Mail/Address.html
@@ -19,6 +19,10 @@
             </f:if>
             <br />
             {billingAddress.email}<br />
+
+            <f:if condition="{billingAddress.taxIdentificationNumber}">
+                <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_address.tax_identification_number" />: {billingAddress.taxIdentificationNumber}<br />
+            </f:if>
         </td>
         <td style="width:300px; vertical-align:top; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
             <b><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_cart.shipping_address" />:</b><br /><br />


### PR DESCRIPTION
Displaying the tax identification number in mails
eases the accounting process when mails are used
for it.

Solves #355