### PR TITLE
[TASK] Cleanup TypoScript orderNumber generation

### DIFF
--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -34,33 +34,6 @@ plugin.tx_cart {
         }
     }
 
-    orderNumber {
-        # cat=plugin.cart//0600; type=text; label= Prefix (prepend) for order confirmation number (e.g. DE).
-        prefix =
-        # cat=plugin.cart//0610; type=text; label= Suffix (append) for order confirmation number (e.g. O).
-        suffix =
-        # cat=plugin.cart//0620; type=int+; label= Offset for order confirmation number: The offset is added to the order confirmation number (e.g. if the offset is 999 the first order confirmation number will be 1000).
-        offset =
-    }
-
-    invoiceNumber {
-        # cat=plugin.cart//0630; type=text; label= Prefix (prepend) for invoice number (e.g. DE).
-        prefix =
-        # cat=plugin.cart//0640; type=text; label= Suffix (append) for invoice number (e.g. I).
-        suffix =
-        # cat=plugin.cart//0650; type=int+; label= Offset for invoice number: The offset is added to the invoice number (e.g. if the offset is 999 the first invoice number will be 1000).
-        offset =
-    }
-
-    deliveryNumber {
-        # cat=plugin.cart//0660; type=text; label= Prefix (prepend) for delivery note number (e.g. DE).
-        prefix =
-        # cat=plugin.cart//0670; type=text; label= Suffix (append) for delivery note number (e.g. I).
-        suffix =
-        # cat=plugin.cart//0680; type=int+; label= Offset for delivery note number: The offset is added to the delivery note number (e.g. if the offset is 999 the first delivery note number will be 1000).
-        offset =
-    }
-
     settings {
         addToCartByAjax = 2278001
 


### PR DESCRIPTION
With https://github.com/extcode/cart/commit/5c13a1ec30e22df3660327eb7ca24fa037f470b7#diff-b283fa76060bccbae79c0465294ef56f7ebf57b8e70dab356a1d7c48d7f00ee9 the definition of the orderNumberGenerator moved
to `Services.yaml`.
It was missed to remove the definition in the
`constants.typoscript` which is now done.

This issue was triggered by feedback in #399 