### PR TITLE
[TASK] Labels in emails overwriteable

### DIFF
--- a/Documentation/Faq/Index.rst
+++ b/Documentation/Faq/Index.rst
@@ -5,6 +5,8 @@
 FAQ
 ===
 
+.. rst-class:: panel panel-default
+
 How can I unset the predefined payment / shipping methods?
 ==========================================================
 
@@ -49,6 +51,8 @@ add options for 2 other countries instead.
        }
    }
 
+.. rst-class:: panel panel-default
+
 How can I add a field "Addition" for the addresses?
 ===================================================
 
@@ -64,19 +68,21 @@ The following configuration shows the "addition" field for the shipping address:
        addition >
    }
 
+.. rst-class:: panel panel-default
+
 How can overwrite a translation?
 ================================
 
-This can be done in TypoScript, the following code snippet shows an example.
+You can write your own XLIFF file where you are using the key of the translation
+that you want to overwrite. Your XLIFF file needs to be registered in a
+:php:`ext_localconf.php`, e.g. in your sitepackage.
 
-.. code-block:: typoscript
-   caption: EXT:sitepackage/Configuration/TypoScript/setup.typoscript
+The following example is for overwriting German translations:
 
-   plugin.tx_cart {
-     _LOCAL_LANG {
-       de {
-         tx_cart.mail.thank_you_for_order = Ganz herzlichen Dank für deine Bestellung!
-       }
-     }
-   }
+.. code-block:: php
+   :caption: EXT:sitepackage/ext_localconf.php
+
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']
+      ['de']['EXT:cart/Resources/Private/Language/locallang.xlf'][] =
+         'EXT:sitepackage/Resources/Private/Language/Cart/de.locallang.xlf';
 

--- a/Documentation/Faq/Index.rst
+++ b/Documentation/Faq/Index.rst
@@ -58,8 +58,25 @@ shown because the validation is set to `NotEmpty`.
 The following configuration shows the "addition" field for the shipping address:
 
 .. code-block:: typoscript
+   caption: EXT:sitepackage/Configuration/TypoScript/setup.typoscript
 
    plugin.tx_cart.settings.validation.shippingAddress.fields {
        addition >
+   }
+
+How can overwrite a translation?
+================================
+
+This can be done in TypoScript, the following code snippet shows an example.
+
+.. code-block:: typoscript
+   caption: EXT:sitepackage/Configuration/TypoScript/setup.typoscript
+
+   plugin.tx_cart {
+     _LOCAL_LANG {
+       de {
+         tx_cart.mail.thank_you_for_order = Ganz herzlichen Dank für deine Bestellung!
+       }
+     }
    }
 

--- a/Resources/Private/Partials/Mail/Address.html
+++ b/Resources/Private/Partials/Mail/Address.html
@@ -4,7 +4,7 @@
 <table style="text-align: left; padding: 0;margin: 0; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
     <tr>
         <td style="width:300px; vertical-align:top; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-            <b><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_cart.billing_address" />:</b><br /><br />
+            <b><f:translate extensionName="Cart" key="tx_cart_domain_model_cart.billing_address" />:</b><br /><br />
             <f:if condition="{billingAddress.company}">
                 {billingAddress.company}<br />
             </f:if>
@@ -15,17 +15,17 @@
             </f:if>
             {billingAddress.zip} {billingAddress.city}<br />
             <f:if condition="{billingAddress.country}">
-                <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.settings.allowed_countries.{billingAddress.country}" default="{billingAddress.country}"/><br />
+                <f:translate extensionName="Cart" key="tx_cart.settings.allowed_countries.{billingAddress.country}" default="{billingAddress.country}"/><br />
             </f:if>
             <br />
             {billingAddress.email}<br />
 
             <f:if condition="{billingAddress.taxIdentificationNumber}">
-                <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_address.tax_identification_number" />: {billingAddress.taxIdentificationNumber}<br />
+                <f:translate extensionName="Cart" key="tx_cart_domain_model_order_address.tax_identification_number" />: {billingAddress.taxIdentificationNumber}<br />
             </f:if>
         </td>
         <td style="width:300px; vertical-align:top; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-            <b><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_cart.shipping_address" />:</b><br /><br />
+            <b><f:translate extensionName="Cart" key="tx_cart_domain_model_cart.shipping_address" />:</b><br /><br />
             <f:if condition="{shippingAddress}">
                 <f:then>
                     <f:if condition="{shippingAddress.company}">
@@ -38,11 +38,11 @@
                     </f:if>
                     {shippingAddress.zip} {shippingAddress.city}<br />
                     <f:if condition="{shippingAddress.country}">
-                        <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.settings.allowed_countries.{shippingAddress.country}" default="{shippingAddress.country}"/><br />
+                        <f:translate extensionName="Cart" key="tx_cart.settings.allowed_countries.{shippingAddress.country}" default="{shippingAddress.country}"/><br />
                     </f:if>
                 </f:then>
                 <f:else>
-                    <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_cart.use_billing_address" /><br /><br />
+                    <f:translate extensionName="Cart" key="tx_cart_domain_model_cart.use_billing_address" /><br /><br />
                 </f:else>
             </f:if>
         </td>

--- a/Resources/Private/Partials/Mail/Cart.html
+++ b/Resources/Private/Partials/Mail/Cart.html
@@ -11,16 +11,16 @@
     <thead>
     <tr class="first last" style="background-color:#2d4554; color:#fff;">
         <th colspan="2" rowspan="1" height="34" valign="center" style="text-align: left; padding: 0 10px; margin: 0; font-family: Arial, Helvetica, sans-serif; font-size: 12px; border: none;">
-            <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_product.title"/>
+            <f:translate extensionName="Cart" key="tx_cart_domain_model_order_product.title"/>
         </th>
         <th colspan="1" height="34" class="a-center" valign="center" style="padding: 0 10px; margin: 0; font-family: Arial, Helvetica, sans-serif; font-size: 12px; border: none;">
-            <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_product.price"/>
+            <f:translate extensionName="Cart" key="tx_cart_domain_model_order_product.price"/>
         </th>
         <th colspan="1" height="34" class="a-center" valign="center" style="padding: 0 10px; margin: 0; font-family: Arial, Helvetica, sans-serif; font-size: 12px; border: none;">
-            <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_product.count"/>
+            <f:translate extensionName="Cart" key="tx_cart_domain_model_order_product.count"/>
         </th>
         <th colspan="1" height="34" class="a-center" valign="center" style="padding: 0 10px; margin: 0; font-family: Arial, Helvetica, sans-serif; font-size: 12px; border: none;">
-            <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_product.price_total"/>
+            <f:translate extensionName="Cart" key="tx_cart_domain_model_order_product.price_total"/>
         </th>
     </tr>
     </thead>

--- a/Resources/Private/Partials/Mail/CartSummary.html
+++ b/Resources/Private/Partials/Mail/CartSummary.html
@@ -10,7 +10,7 @@
 <f:if condition="{settings.showCartAction.summary.fields.cart.net}">
     <tr class="first">
         <td colspan="4" style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-            <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_cart_cart.net"/>
+            <f:translate extensionName="Cart" key="tx_cart_domain_model_cart_cart.net"/>
         </td>
         <td style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
             <span class="price">
@@ -22,7 +22,7 @@
 <f:if condition="{settings.showCartAction.summary.fields.cart.gross}">
     <tr>
         <td colspan="4" style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-            <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_cart_cart.gross"/>
+            <f:translate extensionName="Cart" key="tx_cart_domain_model_cart_cart.gross"/>
         </td>
         <td style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
             <span class="price">
@@ -39,7 +39,7 @@
     <f:if condition="{settings.showCartAction.summary.fields.discount.net}">
         <tr>
             <td colspan="4" style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-                <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_product.discount_net"/>
+                <f:translate extensionName="Cart" key="tx_cart_domain_model_order_product.discount_net"/>
             </td>
             <td style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
                 <span class="price">
@@ -51,7 +51,7 @@
     <f:if condition="{settings.showCartAction.summary.fields.discount.gross}">
         <tr>
             <td colspan="4" style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-                <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_product.discount_gross"/>
+                <f:translate extensionName="Cart" key="tx_cart_domain_model_order_product.discount_gross"/>
             </td>
             <td style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
                 <span class="price">
@@ -68,7 +68,7 @@
 <f:if condition="{settings.showCartAction.summary.fields.service.net}">
     <tr>
         <td colspan="4" style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-            <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_product.service_net"/>
+            <f:translate extensionName="Cart" key="tx_cart_domain_model_order_product.service_net"/>
         </td>
         <td style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
             <span class="price">
@@ -80,7 +80,7 @@
 <f:if condition="{settings.showCartAction.summary.fields.service.gross}">
     <tr>
         <td colspan="4" style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-            <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_product.service_gross"/>
+            <f:translate extensionName="Cart" key="tx_cart_domain_model_order_product.service_gross"/>
         </td>
         <td style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
             <span class="price">
@@ -96,7 +96,7 @@
 <f:if condition="{settings.showCartAction.summary.fields.total.net}">
     <tr>
         <td colspan="4" style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-            <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_product.total_net"/>
+            <f:translate extensionName="Cart" key="tx_cart_domain_model_order_product.total_net"/>
         </td>
         <td style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
             <span class="price">
@@ -108,7 +108,7 @@
 <f:if condition="{settings.showCartAction.summary.fields.total.gross}">
     <tr>
         <td colspan="4" style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-            <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_product.total_gross"/>
+            <f:translate extensionName="Cart" key="tx_cart_domain_model_order_product.total_gross"/>
         </td>
         <td style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
             <span class="price">

--- a/Resources/Private/Partials/Mail/Header.html
+++ b/Resources/Private/Partials/Mail/Header.html
@@ -2,11 +2,11 @@
       data-namespace-typo3-fluid="true">
 
 <p style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-    <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.salutation" arguments="{0: orderItem.billingAddress.salutationOrTitleLastName}"/>
+    <f:translate extensionName="Cart" key="tx_cart.mail.salutation" arguments="{0: orderItem.billingAddress.salutationOrTitleLastName}"/>
 </p>
 
 <p style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-    <b><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.thank_you_for_order" /></b> <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.thank_you_for_order_note" />
+    <b><f:translate extensionName="Cart" key="tx_cart.mail.thank_you_for_order" /></b> <f:translate extensionName="Cart" key="tx_cart.mail.thank_you_for_order_note" />
 </p>
 
 <f:cObject typoscriptObjectPath="lib.cartMailHeader" />

--- a/Resources/Private/Partials/Mail/OrderInformation.html
+++ b/Resources/Private/Partials/Mail/OrderInformation.html
@@ -7,7 +7,7 @@
     </tr>
     <tr>
         <td width="600" height="34" valign="center" style="background-color:#2d4554; color:#fff; padding: 0 10px; margin: 0; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-            <b><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.order_information" /></b>
+            <b><f:translate extensionName="Cart" key="tx_cart.mail.order_information" /></b>
         </td>
     </tr>
     <tr>

--- a/Resources/Private/Partials/Mail/OrderSummary.html
+++ b/Resources/Private/Partials/Mail/OrderSummary.html
@@ -7,7 +7,7 @@
     </tr>
     <tr>
         <td width="600" height="34" valign="center" style="background-color:#2d4554; color:#fff; padding: 0 10px; margin: 0; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-            <b><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.order_summary" /></b>
+            <b><f:translate extensionName="Cart" key="tx_cart.mail.order_summary" /></b>
         </td>
     </tr>
     <tr>
@@ -19,25 +19,25 @@
     <tbody>
     <f:if condition="{orderItem.orderNumber}">
         <tr>
-            <td colspan="2" style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;"><b><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_item.order_number" /></b></td>
+            <td colspan="2" style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;"><b><f:translate extensionName="Cart" key="tx_cart_domain_model_order_item.order_number" /></b></td>
             <td style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;">: {orderItem.orderNumber}</td>
         </tr>
     </f:if>
     <tr>
-        <td colspan="2" style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;"><b><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_item.order_date" /></b></td>
+        <td colspan="2" style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;"><b><f:translate extensionName="Cart" key="tx_cart_domain_model_order_item.order_date" /></b></td>
         <td style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;">: <f:format.date format="d.m.Y" date="{orderItem.orderDate}" /></td>
     </tr>
     <tr>
-        <td colspan="2" style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;"><b><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.payment_method" /></b></td>
+        <td colspan="2" style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;"><b><f:translate extensionName="Cart" key="tx_cart.mail.payment_method" /></b></td>
         <td style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;">: {orderItem.payment.name}</td>
     </tr>
     <tr>
-        <td colspan="2" style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;"><b><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.shipping_method" /></b></td>
+        <td colspan="2" style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;"><b><f:translate extensionName="Cart" key="tx_cart.mail.shipping_method" /></b></td>
         <td style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;">: {orderItem.shipping.name}</td>
     </tr>
     <f:if condition="{orderItem.comment}">
         <tr>
-            <td colspan="2" style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;"><b><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_item.comment" /></b></td>
+            <td colspan="2" style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;"><b><f:translate extensionName="Cart" key="tx_cart_domain_model_order_item.comment" /></b></td>
             <td style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;">: {orderItem.comment}</td>
         </tr>
     </f:if>

--- a/Resources/Private/Partials/Mail/ProductList.html
+++ b/Resources/Private/Partials/Mail/ProductList.html
@@ -7,7 +7,7 @@
         <td colspan="2" style="padding: 5px 10px; margin: 0; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
             <div class="product-name">{product.title} - {product.feVariant.value}</div>
             <p style="font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-                <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_product.sku.short"/>
+                <f:translate extensionName="Cart" key="tx_cart_domain_model_order_product.sku.short"/>
                 : {product.sku}
             </p>
         </td>
@@ -38,7 +38,7 @@
                 <td style="padding: 5px 10px; margin: 0; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
                     <div class="product-name">{variant.title}</div>
                     <p style="padding: 5px 10px; margin: 0; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
-                        <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_product.sku.short"/>
+                        <f:translate extensionName="Cart" key="tx_cart_domain_model_order_product.sku.short"/>
                         : {variant.completeSku}
                     </p>
                 </td>

--- a/Resources/Private/Partials/Mail/TaxList.html
+++ b/Resources/Private/Partials/Mail/TaxList.html
@@ -6,7 +6,7 @@
     <tr>
         <td colspan="4" style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">
             <cart:traversable.extract key="{tax_key}" content="{taxClasses}" as="taxClass">
-                <f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.tax_vat.value" arguments="{0: taxClass.value}"/>
+                <f:translate extensionName="Cart" key="tx_cart.tax_vat.value" arguments="{0: taxClass.value}"/>
             </cart:traversable.extract>
         </td>
         <td style="padding: 5px 10px; margin: 0; text-align: right; font-family: Arial, Helvetica, sans-serif; font-size: 12px;">

--- a/Resources/Private/Templates/Mail/Open/Buyer.html
+++ b/Resources/Private/Templates/Mail/Open/Buyer.html
@@ -2,8 +2,8 @@
       data-namespace-typo3-fluid="true">
 
 <f:layout name="SystemEmail" />
-<f:section name="Title"><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.buyer.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
-<f:section name="Subject"><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.buyer.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
+<f:section name="Title"><f:translate extensionName="Cart" key="tx_cart.mail.buyer.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
+<f:section name="Subject"><f:translate extensionName="Cart" key="tx_cart.mail.buyer.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
 <f:section name="Main">
     <f:render partial="Mail/Header" arguments="{_all}"/>
 

--- a/Resources/Private/Templates/Mail/Open/Seller.html
+++ b/Resources/Private/Templates/Mail/Open/Seller.html
@@ -2,8 +2,8 @@
       data-namespace-typo3-fluid="true">
 
 <f:layout name="SystemEmail" />
-<f:section name="Title"><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.seller.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
-<f:section name="Subject"><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.seller.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
+<f:section name="Title"><f:translate extensionName="Cart" key="tx_cart.mail.seller.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
+<f:section name="Subject"><f:translate extensionName="Cart" key="tx_cart.mail.seller.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
 <f:section name="Main">
     <f:render partial="Mail/OrderInformation" arguments="{_all}"/>
 

--- a/Resources/Private/Templates/Mail/Paid/Buyer.html
+++ b/Resources/Private/Templates/Mail/Paid/Buyer.html
@@ -2,8 +2,8 @@
       data-namespace-typo3-fluid="true">
 
 <f:layout name="SystemEmail" />
-<f:section name="Title"><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.buyer.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
-<f:section name="Subject"><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.buyer.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
+<f:section name="Title"><f:translate extensionName="Cart" key="tx_cart.mail.buyer.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
+<f:section name="Subject"><f:translate extensionName="Cart" key="tx_cart.mail.buyer.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
 <f:section name="Main">
     <f:render partial="Mail/Header" arguments="{_all}"/>
 

--- a/Resources/Private/Templates/Mail/Paid/Seller.html
+++ b/Resources/Private/Templates/Mail/Paid/Seller.html
@@ -2,8 +2,8 @@
       data-namespace-typo3-fluid="true">
 
 <f:layout name="SystemEmail" />
-<f:section name="Title"><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.seller.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
-<f:section name="Subject"><f:translate key="LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart.mail.seller.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
+<f:section name="Title"><f:translate extensionName="Cart" key="tx_cart.mail.seller.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
+<f:section name="Subject"><f:translate extensionName="Cart" key="tx_cart.mail.seller.subject" arguments="{0: orderItem.orderNumber}" /></f:section>
 <f:section name="Main">
     <f:render partial="Mail/OrderInformation" arguments="{_all}"/>
 


### PR DESCRIPTION
Using the attribute `extensionName`
in <f:translate> tags makes it
possible to overwrite them with own
translations.

The method to overwrite a labels is
even added to the FAQ section of the
documentation.

Fixes #401