### PR TITLE
Add order comment in backend module

### DIFF
--- a/Resources/Private/Partials/Backend/Order/Show/Address.html
+++ b/Resources/Private/Partials/Backend/Order/Show/Address.html
@@ -32,9 +32,11 @@
         <f:if condition="{address.taxIdentificationNumber}">
             <br/>
             <div>
+                <strong><f:translate key="tx_cart_domain_model_order_address.tax_identification_number"/>:<br/></strong>
                 {address.taxIdentificationNumber}
             </div>
         </f:if>
+
     </div>
 </f:section>
 

--- a/Resources/Private/Templates/Backend/Order/Order/Show.html
+++ b/Resources/Private/Templates/Backend/Order/Order/Show.html
@@ -17,6 +17,13 @@
         <f:render partial="Backend/Order/Show/Address" arguments="{orderItem: orderItem}"/>
     </div>
 
+    <f:if condition="{orderItem.comment}">
+        <div style="padding-bottom: 20px;">
+            <strong><f:translate key="tx_cart_domain_model_order_item.comment"/>:</strong><br/>
+            {orderItem.comment -> f:sanitize.html()}
+        </div>
+    </f:if>
+
     <div style="padding-bottom: 20px;">
         <f:render partial="Backend/Order/Show/Cart" arguments="{orderItem: orderItem}"/>
     </div>


### PR DESCRIPTION
* Add order comment in detail backend view of an order (fixes #358)
* Improve styling of label of tax identification number (missed in #355)