### PR TITLE
[TASK] Remove v12 deprecations

### DIFF
--- a/Classes/Controller/Backend/ActionController.php
+++ b/Classes/Controller/Backend/ActionController.php
@@ -26,7 +26,7 @@ class ActionController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
                 ConfigurationManager::CONFIGURATION_TYPE_FRAMEWORK
             );
 
-        $pageId = (int)(GeneralUtility::_GET('id')) ? GeneralUtility::_GET('id') : 1;
+        $pageId = (int)$this->request->getQueryParams()['id'] ?? 1;
 
         BackendUtility::readPageAccess(
             $pageId,

--- a/Classes/Controller/Backend/Order/OrderController.php
+++ b/Classes/Controller/Backend/Order/OrderController.php
@@ -19,10 +19,9 @@ use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Imaging\IconFactory;
-use TYPO3\CMS\Core\Messaging\AbstractMessage;
 use TYPO3\CMS\Core\Pagination\SimplePagination;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
 use TYPO3\CMS\Extbase\Pagination\QueryResultPaginator;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
@@ -177,7 +176,7 @@ class OrderController extends ActionController
                 'Cart'
             );
 
-            $this->addFlashMessage($msg, '', AbstractMessage::ERROR);
+            $this->addFlashMessage($msg, '', ContextualFeedbackSeverity::ERROR);
         }
 
         $this->redirect('show', 'Backend\Order\Order', null, ['orderItem' => $orderItem]);

--- a/Classes/Controller/Cart/CouponController.php
+++ b/Classes/Controller/Cart/CouponController.php
@@ -15,7 +15,7 @@ use Extcode\Cart\Domain\Model\Cart\CartCouponInterface;
 use Extcode\Cart\Domain\Model\Coupon;
 use Extcode\Cart\Domain\Repository\CouponRepository;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Messaging\AbstractMessage;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
@@ -71,7 +71,7 @@ class CouponController extends ActionController
                                 'Cart'
                             ),
                             '',
-                            AbstractMessage::OK,
+                            ContextualFeedbackSeverity::OK,
                             true
                         );
                     }
@@ -82,7 +82,7 @@ class CouponController extends ActionController
                                 'Cart'
                             ),
                             '',
-                            AbstractMessage::WARNING,
+                            ContextualFeedbackSeverity::WARNING,
                             true
                         );
                     }
@@ -93,7 +93,7 @@ class CouponController extends ActionController
                                 'Cart'
                             ),
                             '',
-                            AbstractMessage::WARNING,
+                            ContextualFeedbackSeverity::WARNING,
                             true
                         );
                     }
@@ -104,7 +104,7 @@ class CouponController extends ActionController
                             'Cart'
                         ),
                         '',
-                        AbstractMessage::WARNING,
+                        ContextualFeedbackSeverity::WARNING,
                         true
                     );
                 }
@@ -115,7 +115,7 @@ class CouponController extends ActionController
                         'Cart'
                     ),
                     '',
-                    AbstractMessage::WARNING,
+                    ContextualFeedbackSeverity::WARNING,
                     true
                 );
             }
@@ -142,7 +142,7 @@ class CouponController extends ActionController
                         'Cart'
                     ),
                     '',
-                    AbstractMessage::OK,
+                    ContextualFeedbackSeverity::OK,
                     true
                 );
             }
@@ -153,7 +153,7 @@ class CouponController extends ActionController
                         'Cart'
                     ),
                     '',
-                    AbstractMessage::WARNING,
+                    ContextualFeedbackSeverity::WARNING,
                     true
                 );
             }

--- a/Classes/Controller/Cart/PaymentController.php
+++ b/Classes/Controller/Cart/PaymentController.php
@@ -12,7 +12,7 @@ namespace Extcode\Cart\Controller\Cart;
  */
 
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Messaging\AbstractMessage;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 class PaymentController extends ActionController
@@ -37,7 +37,7 @@ class PaymentController extends ActionController
                         'Cart'
                     ),
                     '',
-                    AbstractMessage::ERROR,
+                    ContextualFeedbackSeverity::ERROR,
                     true
                 );
             }

--- a/Classes/Controller/Cart/ShippingController.php
+++ b/Classes/Controller/Cart/ShippingController.php
@@ -12,7 +12,7 @@ namespace Extcode\Cart\Controller\Cart;
  */
 
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Messaging\AbstractMessage;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 class ShippingController extends ActionController
@@ -37,7 +37,7 @@ class ShippingController extends ActionController
                         'Cart'
                     ),
                     '',
-                    AbstractMessage::ERROR,
+                    ContextualFeedbackSeverity::ERROR,
                     true
                 );
             }

--- a/Classes/Controller/Order/OrderController.php
+++ b/Classes/Controller/Order/OrderController.php
@@ -13,8 +13,8 @@ namespace Extcode\Cart\Controller\Order;
 use Extcode\Cart\Domain\Model\Order\Item;
 use Extcode\Cart\Domain\Repository\Order\ItemRepository;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Messaging\AbstractMessage;
 use TYPO3\CMS\Core\Pagination\SimplePagination;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
@@ -80,7 +80,7 @@ class OrderController extends ActionController
             $this->addFlashMessage(
                 'Access denied.',
                 '',
-                AbstractMessage::ERROR
+                ContextualFeedbackSeverity::ERROR
             );
             $this->redirect('list');
         }

--- a/Classes/Domain/Finisher/Form/AddToCartFinisher.php
+++ b/Classes/Domain/Finisher/Form/AddToCartFinisher.php
@@ -16,9 +16,9 @@ use Extcode\Cart\Service\SessionHandler;
 use Extcode\Cart\Utility\CartUtility;
 use TYPO3\CMS\Core\Http\PropagateResponseException;
 use TYPO3\CMS\Core\Http\StreamFactory;
-use TYPO3\CMS\Core\Messaging\AbstractMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Extbase\Service\ExtensionService;
@@ -90,7 +90,7 @@ class AddToCartFinisher extends AbstractFinisher
             $status = '200';
             $messageBody = $this->getStatusMessageBody($formValues, $status);
             $messageTitle = $this->getStatusMessageTitle($formValues);
-            $severity = AbstractMessage::OK;
+            $severity = ContextualFeedbackSeverity::OK;
 
             $pageType = $GLOBALS['TYPO3_REQUEST']->getAttribute('routing')->getPageType();
             if (in_array((int)$pageType, $this->configurations['settings']['jsonResponseForPageTypes'])) {


### PR DESCRIPTION
* Do no longer use `GeneralUtility::_GET(), see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Deprecation-92947-DeprecateTYPO3_MODEAndTYPO3_REQUESTTYPEConstants.html
* Do no longer use `AbstractMessage`, see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-97787-AbstractMessageGetSeverityReturnsContextualFeedbackSeverity.html

Related: #433