### PR TITLE
Fix falsy formated figures in BE views

### DIFF
--- a/Classes/Controller/Backend/Order/OrderController.php
+++ b/Classes/Controller/Backend/Order/OrderController.php
@@ -65,6 +65,7 @@ class OrderController extends ActionController
     {
         $this->moduleTemplate = $this->moduleTemplateFactory->create($this->request);
 
+        $this->moduleTemplate->assign('settings', $this->settings);
         $this->moduleTemplate->assign('searchArguments', $this->searchArguments);
 
         $itemsPerPage = $this->settings['itemsPerPage'] ?? 20;
@@ -124,6 +125,7 @@ class OrderController extends ActionController
     {
         $this->moduleTemplate = $this->moduleTemplateFactory->create($this->request);
 
+        $this->moduleTemplate->assign('settings', $this->settings);
         $this->moduleTemplate->assign('orderItem', $orderItem);
 
         $paymentStatusOptions = [];

--- a/Classes/Controller/Backend/Order/OrderController.php
+++ b/Classes/Controller/Backend/Order/OrderController.php
@@ -22,6 +22,7 @@ use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Pagination\SimplePagination;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Extbase\Annotation\IgnoreValidation;
 use TYPO3\CMS\Extbase\Pagination\QueryResultPaginator;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;

--- a/Classes/ViewHelpers/Format/CurrencyViewHelper.php
+++ b/Classes/ViewHelpers/Format/CurrencyViewHelper.php
@@ -130,10 +130,12 @@ class CurrencyViewHelper extends AbstractViewHelper
             if (!isset($separateCurrency) && isset($currencyFormat['separateCurrency'])) {
                 $separateCurrency = filter_var($currencyFormat['separateCurrency'], FILTER_VALIDATE_BOOLEAN);
             }
-            if (!isset($decimals) && isset($currencyFormat['decimals'])) {
-                $decimals = (int)($currencyFormat['decimals']);
-            } else {
-                $decimals = 0;
+            if (!isset($decimals)){
+                if(isset($currencyFormat['decimals'])) {
+                    $decimals = (int)($currencyFormat['decimals']);
+                } else {
+                    $decimals = 0;
+                }
             }
         }
 

--- a/Resources/Private/Partials/Backend/Order/Show/CartTable/Footer.html
+++ b/Resources/Private/Partials/Backend/Order/Show/CartTable/Footer.html
@@ -101,29 +101,14 @@
         <f:translate key="tx_cart_domain_model_order_item.cart_total_price"/>
     </td>
     <td>
-        <cart:format.currency currencySign="{orderItem.currency}"
-                           decimalSeparator="{settings.format.currency.decimalSeparator}"
-                           thousandsSeparator="{settings.format.currency.thousandsSeparator}"
-                           prependCurrency="{settings.format.currency.prependCurrency}"
-                           separateCurrency="{settings.format.currency.separateCurrency}"
-                           decimals="{settings.format.currency.decimals}">{orderItem.totalNet}</cart:format.currency>
+        <cart:format.currency currencySign="{orderItem.currency}">{orderItem.totalNet}</cart:format.currency>
     </td>
     <td>
-        <cart:format.currency currencySign="{orderItem.currency}"
-                           decimalSeparator="{settings.format.currency.decimalSeparator}"
-                           thousandsSeparator="{settings.format.currency.thousandsSeparator}"
-                           prependCurrency="{settings.format.currency.prependCurrency}"
-                           separateCurrency="{settings.format.currency.separateCurrency}"
-                           decimals="{settings.format.currency.decimals}">{orderItem.totalGross}</cart:format.currency>
+        <cart:format.currency currencySign="{orderItem.currency}">{orderItem.totalGross}</cart:format.currency>
     </td>
     <f:for each="{orderItem.orderTotalTax}" as="orderTotalTax">
         <td>
-            <cart:format.currency currencySign="{orderItem.currency}"
-                               decimalSeparator="{settings.format.currency.decimalSeparator}"
-                               thousandsSeparator="{settings.format.currency.thousandsSeparator}"
-                               prependCurrency="{settings.format.currency.prependCurrency}"
-                               separateCurrency="{settings.format.currency.separateCurrency}"
-                               decimals="{settings.format.currency.decimals}">{orderTotalTax.tax}</cart:format.currency>
+            <cart:format.currency currencySign="{orderItem.currency}">{orderTotalTax.tax}</cart:format.currency>
         </td>
     </f:for>
 </tr>


### PR DESCRIPTION
* The TypoScript settings for currencies are considered in the BE view
* The CurrencyViewHelper does no longer ignore the attribute `decimals`.