### PR TITLE
[TASK] Allow names in from email addresses

### DIFF
--- a/Classes/Service/MailHandler.php
+++ b/Classes/Service/MailHandler.php
@@ -15,85 +15,39 @@ use Extcode\Cart\Hooks\MailAttachmentHookInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Mail\FluidEmail;
-use TYPO3\CMS\Core\Mail\Mailer;
+use TYPO3\CMS\Core\Mail\MailerInterface;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 
 class MailHandler implements SingletonInterface
 {
-    /**
-     * @var LogManager
-     */
-    protected $logManager;
-
-    /**
-     * @var ConfigurationManager
-     */
-    protected $configurationManager;
-
-    /**
-     * @var array
-     */
-    protected $pluginSettings = [];
-
-    /**
-     * @var Cart
-     */
-    protected $cart;
-
-    /**
-     * @var string
-     */
-    protected $buyerEmailFrom = '';
-
-    /**
-     * @var string
-     */
-    protected $buyerEmailCc = '';
-
-    /**
-     * @var string
-     */
-    protected $buyerEmailBcc = '';
-
-    /**
-     * @var string
-     */
-    protected $buyerEmailReplyTo = '';
-
-    /**
-     * @var string
-     */
-    protected $sellerEmailFrom = '';
-
-    /**
-     * @var string
-     */
-    protected $sellerEmailTo = '';
-
-    /**
-     * @var string
-     */
-    protected $sellerEmailCc = '';
-
-    /**
-     * @var string
-     */
-    protected $sellerEmailBcc = '';
+    protected LogManager $logManager;
+    protected ConfigurationManager $configurationManager;
+    private MailerInterface $mailer;
+    protected array $pluginSettings = [];
+    protected Cart $cart;
+    protected string $buyerEmailFrom = '';
+    protected string $buyerEmailCc = '';
+    protected string $buyerEmailBcc = '';
+    protected string $buyerEmailReplyTo = '';
+    protected string $sellerEmailFrom = '';
+    protected string $sellerEmailTo = '';
+    protected string $sellerEmailCc = '';
+    protected string $sellerEmailBcc = '';
 
     /**
      * MailHandler constructor
      */
-    public function __construct()
+    public function __construct(
+        LogManager $logManager,
+        ConfigurationManager $configurationManager,
+        MailerInterface $mailer
+    )
     {
-        $this->logManager = GeneralUtility::makeInstance(
-            LogManager::class
-        );
-
-        $this->configurationManager = GeneralUtility::makeInstance(
-            ConfigurationManager::class
-        );
+        $this->logManager = $logManager;
+        $this->configurationManager = $configurationManager;
+        $this->mailer = $mailer;
 
         $this->setPluginSettings();
     }
@@ -109,228 +63,187 @@ class MailHandler implements SingletonInterface
                 'Cart'
             );
 
-        if (!empty($this->pluginSettings['settings'])) {
-            if (!empty($this->pluginSettings['settings']['buyer'])
-                && !empty($this->pluginSettings['settings']['buyer']['emailFromAddress'])
-            ) {
-                $this->setBuyerEmailFrom($this->pluginSettings['settings']['buyer']['emailFromAddress']);
-            } elseif (!empty($this->pluginSettings['mail'])
-                && !empty($this->pluginSettings['mail']['buyer'])
-                && !empty($this->pluginSettings['mail']['buyer']['fromAddress'])
-            ) {
-                $this->setBuyerEmailFrom($this->pluginSettings['mail']['buyer']['fromAddress']);
-            }
+        if (empty($this->pluginSettings['settings'])) {
+            return;
+        }
 
-            if (!empty($this->pluginSettings['settings']['buyer'])
-                && !empty($this->pluginSettings['settings']['buyer']['emailCcAddress'])
-            ) {
-                $this->setBuyerEmailCc($this->pluginSettings['settings']['buyer']['emailCcAddress']);
-            } elseif (!empty($this->pluginSettings['mail'])
-                && !empty($this->pluginSettings['mail']['buyer'])
-                && !empty($this->pluginSettings['mail']['buyer']['ccAddress'])
-            ) {
-                $this->setBuyerEmailCc($this->pluginSettings['mail']['buyer']['ccAddress']);
-            }
+        // setBuyerEmailFrom
+        if (!empty($this->pluginSettings['settings']['buyer'])
+            && !empty($this->pluginSettings['settings']['buyer']['emailFromAddress'])
+        ) {
+            $this->setBuyerEmailFrom($this->pluginSettings['settings']['buyer']['emailFromAddress']);
+        } elseif (!empty($this->pluginSettings['mail'])
+            && !empty($this->pluginSettings['mail']['buyer'])
+            && !empty($this->pluginSettings['mail']['buyer']['fromAddress'])
+        ) {
+            $this->setBuyerEmailFrom($this->pluginSettings['mail']['buyer']['fromAddress']);
+        }
 
-            if (!empty($this->pluginSettings['settings']['buyer'])
-                && !empty($this->pluginSettings['settings']['buyer']['emailBccAddress'])
-            ) {
-                $this->setBuyerEmailBcc($this->pluginSettings['settings']['buyer']['emailBccAddress']);
-            } elseif (!empty($this->pluginSettings['mail'])
-                && !empty($this->pluginSettings['mail']['buyer'])
-                && !empty($this->pluginSettings['mail']['buyer']['bccAddress'])
-            ) {
-                $this->setBuyerEmailBcc($this->pluginSettings['mail']['buyer']['bccAddress']);
-            }
+        // setBuyerEmailCc
+        if (!empty($this->pluginSettings['settings']['buyer'])
+            && !empty($this->pluginSettings['settings']['buyer']['emailCcAddress'])
+        ) {
+            $this->setBuyerEmailCc($this->pluginSettings['settings']['buyer']['emailCcAddress']);
+        } elseif (!empty($this->pluginSettings['mail'])
+            && !empty($this->pluginSettings['mail']['buyer'])
+            && !empty($this->pluginSettings['mail']['buyer']['ccAddress'])
+        ) {
+            $this->setBuyerEmailCc($this->pluginSettings['mail']['buyer']['ccAddress']);
+        }
 
-            if (!empty($this->pluginSettings['settings']['buyer'])
-                && !empty($this->pluginSettings['settings']['buyer']['emailReplyToAddress'])
-            ) {
-                $this->setBuyerEmailReplyTo($this->pluginSettings['settings']['buyer']['emailReplyToAddress']);
-            } elseif (!empty($this->pluginSettings['mail'])
-                && !empty($this->pluginSettings['mail']['buyer'])
-                && !empty($this->pluginSettings['mail']['buyer']['replyToAddress'])
-            ) {
-                $this->setBuyerEmailReplyTo($this->pluginSettings['mail']['buyer']['replyToAddress']);
-            }
+        // setBuyerEmailBcc
+        if (!empty($this->pluginSettings['settings']['buyer'])
+            && !empty($this->pluginSettings['settings']['buyer']['emailBccAddress'])
+        ) {
+            $this->setBuyerEmailBcc($this->pluginSettings['settings']['buyer']['emailBccAddress']);
+        } elseif (!empty($this->pluginSettings['mail'])
+            && !empty($this->pluginSettings['mail']['buyer'])
+            && !empty($this->pluginSettings['mail']['buyer']['bccAddress'])
+        ) {
+            $this->setBuyerEmailBcc($this->pluginSettings['mail']['buyer']['bccAddress']);
+        }
 
-            if (!empty($this->pluginSettings['settings']['seller'])
-                && !empty($this->pluginSettings['settings']['seller']['emailFromAddress'])
-            ) {
-                $this->setSellerEmailFrom($this->pluginSettings['settings']['seller']['emailFromAddress']);
-            } elseif (!empty($this->pluginSettings['mail'])
-                && !empty($this->pluginSettings['mail']['seller'])
-                && !empty($this->pluginSettings['mail']['seller']['fromAddress'])
-            ) {
-                $this->setSellerEmailFrom($this->pluginSettings['mail']['seller']['fromAddress']);
-            }
+        // setBuyerEmailReplyTo
+        if (!empty($this->pluginSettings['settings']['buyer'])
+            && !empty($this->pluginSettings['settings']['buyer']['emailReplyToAddress'])
+        ) {
+            $this->setBuyerEmailReplyTo($this->pluginSettings['settings']['buyer']['emailReplyToAddress']);
+        } elseif (!empty($this->pluginSettings['mail'])
+            && !empty($this->pluginSettings['mail']['buyer'])
+            && !empty($this->pluginSettings['mail']['buyer']['replyToAddress'])
+        ) {
+            $this->setBuyerEmailReplyTo($this->pluginSettings['mail']['buyer']['replyToAddress']);
+        }
 
-            if (!empty($this->pluginSettings['settings']['seller'])
-                && !empty($this->pluginSettings['settings']['seller']['emailToAddress'])
-            ) {
-                $this->setSellerEmailTo($this->pluginSettings['settings']['seller']['emailToAddress']);
-            } elseif (!empty($this->pluginSettings['mail'])
-                && !empty($this->pluginSettings['mail']['seller'])
-                && !empty($this->pluginSettings['mail']['seller']['toAddress'])
-            ) {
-                $this->setSellerEmailTo($this->pluginSettings['mail']['seller']['toAddress']);
-            }
+        // setSellerEmailFrom
+        if (!empty($this->pluginSettings['settings']['seller'])
+            && !empty($this->pluginSettings['settings']['seller']['emailFromAddress'])
+        ) {
+            $this->setSellerEmailFrom($this->pluginSettings['settings']['seller']['emailFromAddress']);
+        } elseif (!empty($this->pluginSettings['mail'])
+            && !empty($this->pluginSettings['mail']['seller'])
+            && !empty($this->pluginSettings['mail']['seller']['fromAddress'])
+        ) {
+            $this->setSellerEmailFrom($this->pluginSettings['mail']['seller']['fromAddress']);
+        }
 
-            if (!empty($this->pluginSettings['settings']['seller'])
-                && !empty($this->pluginSettings['settings']['seller']['emailCcAddress'])
-            ) {
-                $this->setSellerEmailCc($this->pluginSettings['settings']['seller']['emailCcAddress']);
-            } elseif (!empty($this->pluginSettings['mail'])
-                && !empty($this->pluginSettings['mail']['seller'])
-                && !empty($this->pluginSettings['mail']['seller']['ccAddress'])
-            ) {
-                $this->setSellerEmailCc($this->pluginSettings['mail']['seller']['ccAddress']);
-            }
+        // setSellerEmailTo
+        if (!empty($this->pluginSettings['settings']['seller'])
+            && !empty($this->pluginSettings['settings']['seller']['emailToAddress'])
+        ) {
+            $this->setSellerEmailTo($this->pluginSettings['settings']['seller']['emailToAddress']);
+        } elseif (!empty($this->pluginSettings['mail'])
+            && !empty($this->pluginSettings['mail']['seller'])
+            && !empty($this->pluginSettings['mail']['seller']['toAddress'])
+        ) {
+            $this->setSellerEmailTo($this->pluginSettings['mail']['seller']['toAddress']);
+        }
 
-            if (!empty($this->pluginSettings['settings']['seller'])
-                && !empty($this->pluginSettings['settings']['seller']['emailBccAddress'])
-            ) {
-                $this->setSellerEmailBcc($this->pluginSettings['settings']['seller']['emailBccAddress']);
-            } elseif (!empty($this->pluginSettings['mail'])
-                && !empty($this->pluginSettings['mail']['seller'])
-                && !empty($this->pluginSettings['mail']['seller']['bccAddress'])
-            ) {
-                $this->setSellerEmailBcc($this->pluginSettings['mail']['seller']['bccAddress']);
-            }
+        // setSellerEmailCc
+        if (!empty($this->pluginSettings['settings']['seller'])
+            && !empty($this->pluginSettings['settings']['seller']['emailCcAddress'])
+        ) {
+            $this->setSellerEmailCc($this->pluginSettings['settings']['seller']['emailCcAddress']);
+        } elseif (!empty($this->pluginSettings['mail'])
+            && !empty($this->pluginSettings['mail']['seller'])
+            && !empty($this->pluginSettings['mail']['seller']['ccAddress'])
+        ) {
+            $this->setSellerEmailCc($this->pluginSettings['mail']['seller']['ccAddress']);
+        }
+
+        // setSellerEmailBcc
+        if (!empty($this->pluginSettings['settings']['seller'])
+            && !empty($this->pluginSettings['settings']['seller']['emailBccAddress'])
+        ) {
+            $this->setSellerEmailBcc($this->pluginSettings['settings']['seller']['emailBccAddress']);
+        } elseif (!empty($this->pluginSettings['mail'])
+            && !empty($this->pluginSettings['mail']['seller'])
+            && !empty($this->pluginSettings['mail']['seller']['bccAddress'])
+        ) {
+            $this->setSellerEmailBcc($this->pluginSettings['mail']['seller']['bccAddress']);
         }
     }
 
-    /**
-     * @param Cart $cart
-     */
     public function setCart(Cart $cart): void
     {
         $this->cart = $cart;
     }
 
-    /**
-     * @param string $email
-     */
     public function setBuyerEmailFrom(string $email): void
     {
         $this->buyerEmailFrom = $email;
     }
 
-    /**
-     * @return string
-     */
     public function getBuyerEmailFrom(): string
     {
         return $this->buyerEmailFrom;
     }
 
-    /**
-     * @param string $buyerEmailCc
-     */
     public function setBuyerEmailCc(string $buyerEmailCc): void
     {
         $this->buyerEmailCc = $buyerEmailCc;
     }
 
-    /**
-     * @return string
-     */
     public function getBuyerEmailCc(): string
     {
         return $this->buyerEmailCc;
     }
 
-    /**
-     * @param string $buyerEmailBcc
-     */
     public function setBuyerEmailBcc(string $buyerEmailBcc): void
     {
         $this->buyerEmailBcc = $buyerEmailBcc;
     }
 
-    /**
-     * @return string
-     */
     public function getBuyerEmailBcc(): string
     {
         return $this->buyerEmailBcc;
     }
 
-    /**
-     * @param string $buyerEmailReplyTo
-     */
     public function setBuyerEmailReplyTo(string $buyerEmailReplyTo): void
     {
         $this->buyerEmailReplyTo = $buyerEmailReplyTo;
     }
 
-    /**
-     * @return string
-     */
     public function getBuyerEmailReplyTo(): string
     {
         return $this->buyerEmailReplyTo;
     }
 
-    /**
-     * @param string $email
-     */
     public function setSellerEmailFrom(string $email): void
     {
         $this->sellerEmailFrom = $email;
     }
 
-    /**
-     * @return string
-     */
     public function getSellerEmailFrom(): string
     {
         return $this->sellerEmailFrom;
     }
 
-    /**
-     * @param string $email
-     */
     public function setSellerEmailTo(string $email): void
     {
         $this->sellerEmailTo = $email;
     }
 
-    /**
-     * @return string
-     */
     public function getSellerEmailTo(): string
     {
         return $this->sellerEmailTo;
     }
 
-    /**
-     * @param string $sellerEmailCc
-     */
     public function setSellerEmailCc(string $sellerEmailCc): void
     {
         $this->sellerEmailCc = $sellerEmailCc;
     }
 
-    /**
-     * @return string
-     */
     public function getSellerEmailCc(): string
     {
         return $this->sellerEmailCc;
     }
 
-    /**
-     * @param string $sellerEmailBcc
-     */
     public function setSellerEmailBcc(string $sellerEmailBcc): void
     {
         $this->sellerEmailBcc = $sellerEmailBcc;
     }
 
-    /**
-     * @return string
-     */
     public function getSellerEmailBcc(): string
     {
         return $this->sellerEmailBcc;
@@ -338,8 +251,6 @@ class MailHandler implements SingletonInterface
 
     /**
      * Send a Mail to Buyer
-     *
-     * @param Item $orderItem
      */
     public function sendBuyerMail(Item $orderItem): void
     {
@@ -349,7 +260,8 @@ class MailHandler implements SingletonInterface
 
         $status = $orderItem->getPayment()->getStatus();
 
-        $email = GeneralUtility::makeInstance(FluidEmail::class)
+        $email = new FluidEmail();
+        $email
             ->to($orderItem->getBillingAddress()->getEmail())
             ->from($this->getBuyerEmailFrom())
             ->setTemplate('Mail/' . ucfirst($status) . '/Buyer')
@@ -388,13 +300,11 @@ class MailHandler implements SingletonInterface
             $email->setRequest($GLOBALS['TYPO3_REQUEST']);
         }
 
-        GeneralUtility::makeInstance(Mailer::class)->send($email);
+        $this->mailer->send($email);
     }
 
     /**
      * Send a Mail to Seller
-     *
-     * @param Item $orderItem
      */
     public function sendSellerMail(Item $orderItem): void
     {
@@ -406,7 +316,8 @@ class MailHandler implements SingletonInterface
         $status = $orderItem->getPayment()->getStatus();
 
         $to = explode(',', $sellerEmailTo);
-        $email = GeneralUtility::makeInstance(FluidEmail::class)
+        $email = new FluidEmail();
+        $email
             ->to(...$to)
             ->from($this->getSellerEmailFrom())
             ->setTemplate('Mail/' . ucfirst($status) . '/Seller')
@@ -446,6 +357,6 @@ class MailHandler implements SingletonInterface
             $email->setRequest($GLOBALS['TYPO3_REQUEST']);
         }
 
-        GeneralUtility::makeInstance(Mailer::class)->send($email);
+        $this->mailer->send($email);
     }
 }

--- a/Configuration/FlexForms/CartPlugin.xml
+++ b/Configuration/FlexForms/CartPlugin.xml
@@ -10,6 +10,16 @@
                 </TCEforms>
                 <type>array</type>
                 <el>
+                    <settings.seller.emailFromName>
+                        <TCEforms>
+                            <label>
+                                LLL:EXT:cart/Resources/Private/Language/locallang_db.xml:tx_cart.flexform.seller.email_from_name
+                            </label>
+                            <config>
+                                <type>input</type>
+                            </config>
+                        </TCEforms>
+                    </settings.seller.emailFromName>
                     <settings.seller.emailFromAddress>
                         <TCEforms>
                             <label>
@@ -52,6 +62,16 @@
                             </config>
                         </TCEforms>
                     </settings.seller.emailBccAddress>
+                    <settings.buyer.emailFromName>
+                        <TCEforms>
+                            <label>
+                                LLL:EXT:cart/Resources/Private/Language/locallang_db.xml:tx_cart.flexform.buyer.email_from_name
+                            </label>
+                            <config>
+                                <type>input</type>
+                            </config>
+                        </TCEforms>
+                    </settings.buyer.emailFromName>
                     <settings.buyer.emailFromAddress>
                         <TCEforms>
                             <label>

--- a/Documentation/Administrator/Configuration/Order/EMailAddresses/Index.rst
+++ b/Documentation/Administrator/Configuration/Order/EMailAddresses/Index.rst
@@ -12,7 +12,9 @@ the backend via the plugin, but also configured via TypoScript.
 
    plugin.tx_cart {
        mail {
+           // Used for emails sent to the customer (=buyer)
            buyer {
+               fromName = Your Brand name
                fromAddress = cart.buyer.sender@example.com
                ccAddress = cart.buyer.cc1@example.com, cart.buyer.cc2@example.com
                bccAddress = cart.buyer.bcc1@example.com, cart.buyer.bcc2@example.com
@@ -21,7 +23,10 @@ the backend via the plugin, but also configured via TypoScript.
                    1 = EXT:sitepackage/Resources/Public/Files/AGB.pdf
                }
            }
+
+           // Used for emails sent to the shop owner (=seller)
            seller {
+               fromName = Cart TYPO3 System
                fromAddress = cart.seller.sender@example.com
                toAddress = cart.seller.to1@example.com, cart.seller.to2@example.com
                ccAddress = cart.seller.cc1@example.com, cart.seller.cc2@example.com

--- a/Documentation/Changelog/9.0/Feature-301-AllowNamesInFromEmailAddresses.rst
+++ b/Documentation/Changelog/9.0/Feature-301-AllowNamesInFromEmailAddresses.rst
@@ -1,0 +1,48 @@
+.. include:: ../../Includes.txt
+
+=====================================================
+Feature: #301 - Allow names in "from" email addresses
+=====================================================
+
+See :issue:`301`
+
+Description
+===========
+
+It is now possible to define names which will be used when sending emails.
+These names will be shown to the customer and shop owner when receiving mails.
+Before only the email address was shown.
+
+Impact
+======
+
+Negative effects are not expected. No adding the names will just have the same
+result as before.
+
+As with all the other mail settings those in the plugin take precedence.
+
+
+Migration
+=========
+See also :ref:`the documentation for email addresses <adminstration_order_mail>`.
+
+.. code-block:: typoscript
+   :caption: EXT:sitepackage/Configuration/TypoScript/setup.typoscript
+
+    plugin.tx_cart {
+       mail {
+           // Used for emails sent to the customer (=buyer)
+           buyer {
+               fromName = Your Brand name
+               // the other settings as shown in the documentation
+           }
+
+           // Used for emails sent to the shop owner (=seller)
+           seller {
+               fromName = Cart TYPO3 System
+               // the other settings as shown in the documentation
+           }
+       }
+   }
+
+.. index:: TypoScript, Frontend

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -40,6 +40,9 @@
             <trans-unit id="tx_cart.flexform.cartPageId">
                 <source>Cart Page Id</source>
             </trans-unit>
+            <trans-unit id="tx_cart.flexform.seller.email_from_name">
+                <source>Sender email name for email to the Seller</source>
+            </trans-unit>
             <trans-unit id="tx_cart.flexform.seller.email_from_address">
                 <source>Sender email address for email to the Seller</source>
             </trans-unit>
@@ -57,6 +60,9 @@
             </trans-unit>
             <trans-unit id="tx_cart.flexform.seller.email_bcc_address.description">
                 <source>The recipients of e-mails sent to one or more e-mail addresses separated by commas and listed in the so-called BCC (Blind Carbon Copy) field will receive a copy of the sent e-mail without their address being visible to the other specified recipients. (Source: Wikipedia)</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.flexform.buyer.email_from_name">
+                <source>Sender email name for email to the Buyer</source>
             </trans-unit>
             <trans-unit id="tx_cart.flexform.buyer.email_from_address">
                 <source>Sender email address for email to the Buyer</source>


### PR DESCRIPTION
Administrator can set names for the "from"
addresses in TypoScript. Those names will be used
when sending mails after orders to buyer and
seller.


Fixes #301 