### PR TITLE
[TASK] Remove deprecated module path configuration

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -391,20 +391,6 @@ plugin.tx_form.settings.yamlConfigurations {
     1543219101 = EXT:cart/Configuration/Yaml/FormSetup.yaml
 }
 
-module.tx_cart {
-    view {
-        templateRootPaths {
-            0 = EXT:cart/Resources/Private/Backend/Templates/
-        }
-        partialRootPaths {
-            0 = EXT:cart/Resources/Private/Backend/Partials/
-        }
-        layoutRootPaths {
-            0 = EXT:cart/Resources/Private/Backend/Layouts/
-        }
-    }
-}
-
 module.tx_form.settings.yamlConfigurations {
     1543219101 = EXT:cart/Configuration/Yaml/FormSetup.yaml
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -124,13 +124,6 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['cart']['MailAttachmentsHook'][] = MailAt
 call_user_func(static function () {
     ExtensionManagementUtility::addTypoScriptSetup(
         '
-module.tx_cart {
-    view {
-        templateRootPaths.10 = EXT:cart/Resources/Private/Backend/Templates/
-        partialRootPaths.10 = EXT:cart/Resources/Private/Backend/Partials/
-        layoutRootPaths.10 = EXT:cart/Resources/Private/Backend/Layouts/
-    }
-}
 module.tx_dashboard {
     view {
         templateRootPaths.1588697552 = EXT:cart/Resources/Private/Templates/


### PR DESCRIPTION
The paths for BE modules are automatically
configured, see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-96730-SimplifiedExtbackendModuleTemplateAPI.html#feature-96730-simplified-ext-backend-moduletemplate-api