### PR TITLE
[TASK] Clean up language files

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -7,7 +7,7 @@ use Extcode\Cart\Controller\Backend\Order\OrderController;
 use Extcode\Cart\Controller\Backend\Order\PaymentController;
 use Extcode\Cart\Controller\Backend\Order\ShippingController;
 
-$_LLL_db = 'LLL:EXT:cart/Resources/Private/Language/locallang_db.xlf:';
+$_LLL_be = 'LLL:EXT:cart/Resources/Private/Language/locallang_be.xlf:';
 
 /**
  * Definitions for modules provided by EXT:cart
@@ -17,7 +17,7 @@ return [
         'access' => 'user, group',
         'workspaces' => 'live',
         'path' => '/module/cart',
-        'labels' => $_LLL_db . 'tx_cart.module.main',
+        'labels' => $_LLL_be . 'tx_cart.module.main',
         'extensionName' => 'Cart',
         'iconIdentifier' => 'ext-cart-module',
         'navigationComponent' => '@typo3/backend/page-tree/page-tree-element',
@@ -29,7 +29,7 @@ return [
         'workspaces' => 'live',
         'path' => '/module/cart/orders',
         'labels' => [
-            'title' => $_LLL_db . 'tx_cart.module.orders',
+            'title' => $_LLL_be . 'tx_cart.module.orders',
         ],
         'extensionName' => 'Cart',
         'controllerActions' => [

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -3,7 +3,6 @@
 defined('TYPO3') or die();
 
 call_user_func(function () {
-    $_LLL_be = 'LLL:EXT:cart/Resources/Private/Language/locallang_be.xlf:';
     $_LLL_db = 'LLL:EXT:cart/Resources/Private/Language/locallang_db.xlf:';
 
     $GLOBALS['TCA']['pages']['columns']['doktype']['config']['items'][] = [
@@ -12,12 +11,12 @@ call_user_func(function () {
         'apps-pagetree-page-cart-cart',
     ];
     $GLOBALS['TCA']['pages']['columns']['module']['config']['items'][] = [
-        $_LLL_be . 'tcarecords-pages-contains.cart_coupons',
+        $_LLL_db . 'tcarecords-pages-contains.cart_coupons',
         'coupons',
         'apps-pagetree-folder-cart-coupons',
     ];
     $GLOBALS['TCA']['pages']['columns']['module']['config']['items'][] = [
-        $_LLL_be . 'tcarecords-pages-contains.cart_orders',
+        $_LLL_db . 'tcarecords-pages-contains.cart_orders',
         'orders',
         'apps-pagetree-folder-cart-orders',
     ];

--- a/Documentation/Changelog/9.0/Breaking-471-CleanUpLanguageFiles.rst
+++ b/Documentation/Changelog/9.0/Breaking-471-CleanUpLanguageFiles.rst
@@ -1,0 +1,26 @@
+.. include:: ../../Includes.txt
+
+===========================================================
+Breaking: #471 - Clean up language files
+===========================================================
+
+See :issue:`471`
+
+Description
+===========
+
+The language files contained a bigger amount of unused entries and their domains
+were not really clear. Some entries were renamed to clarify their usage in the
+backend.
+
+Affected Installations
+======================
+
+Installations which overwrite backend labels might be affected.
+
+Migration
+=========
+
+You need to check whether the key of your overwrite was changed and adapt it.
+
+.. index:: Backend

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -3,7 +3,6 @@
     <file source-language="en" datatype="plaintext" original="messages" date="2020-05-06T13:18:00Z" product-name="cart">
         <header/>
         <body>
-
             <trans-unit id="tx_cart.error.stock_handling.add">
                 <source>Desired number of this item not available.</source>
             </trans-unit>
@@ -17,7 +16,7 @@
                 <source>%s Items were added to cart.</source>
             </trans-unit>
 
-            <trans-unit id="validator.notempty.empty">
+            <trans-unit id="validator.empty.notempty">
                 <source>The given subject was not empty.</source>
             </trans-unit>
 
@@ -69,72 +68,18 @@
             <trans-unit id="tx_cart_domain_model_cart_product.title">
                 <source>Product</source>
             </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.sku">
-                <source>Stock Keeping Unit</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.sku.short">
-                <source>SKU</source>
-            </trans-unit>
             <trans-unit id="tx_cart_domain_model_cart_product.count">
                 <source>Quantity</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.price">
-                <source>Price</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.price_net">
-                <source>Price (net)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.price_gross">
-                <source>Price (gross)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.price_per_unit">
-                <source>Price per unit</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_cart_product.price_per_unit_net">
                 <source>Price per unit (net)</source>
             </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.price_per_unit_gross">
-                <source>Price per unit (gross)</source>
-            </trans-unit>
             <trans-unit id="tx_cart_domain_model_cart_product.price_subtotal">
                 <source>Subtotal</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.price_subtotal_net">
-                <source>Subtotal (net)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.price_subtotal_gross">
-                <source>Subtotal (gross)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.tax">
-                <source>Tax (%s)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.discount">
-                <source>Discount</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.total_net">
-                <source>Total Price (net)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.total_gross">
-                <source>Total Price (gross)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.service_net">
-                <source>Service- and Shipping costs (net)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.service_gross">
-                <source>Service- and Shipping costs (gross)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.discount_net">
-                <source>Discount (net)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_cart_product.discount_gross">
-                <source>Discount (gross)</source>
             </trans-unit>
 
             <trans-unit id="tx_cart_domain_model_order_product.title">
                 <source>Product</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.productId">
-                <source>Product Id</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_product.sku">
                 <source>Stock Keeping Unit</source>
@@ -154,12 +99,6 @@
             <trans-unit id="tx_cart_domain_model_order_product.total">
                 <source>Total</source>
             </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.tax">
-                <source>Tax (%s)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.empty">
-                <source>Currently there are no products in your cart.</source>
-            </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_product.discount">
                 <source>Discount</source>
             </trans-unit>
@@ -175,80 +114,17 @@
             <trans-unit id="tx_cart_domain_model_order_product.total_gross">
                 <source>Total Price (gross)</source>
             </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.shipping">
-                <source>Shipping Options</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.service_from">
-                <source>from</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.service_each">
-                <source>each</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.shipping_free_from">
-                <source>free shipping from</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.shipping_free_until">
-                <source>free shipping until</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.shipping_available_from">
-                <source>shipping available from</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.shipping_available_until">
-                <source>shipping available until</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.payment">
-                <source>Service Options</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.payment_free_from">
-                <source>free service option from</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.payment_free_until">
-                <source>free service option until</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.payment_available_from">
-                <source>service option available from</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.payment_available_until">
-                <source>service option available until</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.special">
-                <source>Special Options</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.special_free_from">
-                <source>free special option from</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.special_free_until">
-                <source>free special option until</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.special_available_from">
-                <source>special option available from</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.special_available_until">
-                <source>special option available until</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.special_each">
-                <source>%s each</source>
-            </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_product.service_net">
                 <source>Service- and Shipping costs (net)</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_product.service_gross">
                 <source>Service- and Shipping costs (gross)</source>
             </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.discount_net">
+            <trans-unit id="tx_cart_domain_model_order_product.service_net">
                 <source>Discount (net)</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_product.discount_gross">
                 <source>Discount (gross)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.delete">
-                <source>Remove this product from cart.</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.ordernumber">
-                <source>Order number</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.invoicenumber">
-                <source>Invoice number</source>
             </trans-unit>
 
             <trans-unit id="filter">
@@ -270,20 +146,10 @@
                 <source>End Date</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart_domain_model_product.filter.sku">
-                <source>SKU</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_product.filter.title">
-                <source>Title</source>
-            </trans-unit>
-
             <trans-unit id="tx_cart.format.date">
                 <source>Y-m-d</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart.add_product">
-                <source>add to cart</source>
-            </trans-unit>
             <trans-unit id="tx_cart.remove_product">
                 <source>remove</source>
             </trans-unit>
@@ -308,9 +174,6 @@
             <trans-unit id="tx_cart.same_address">
                 <source>Send it to the same address.</source>
             </trans-unit>
-            <trans-unit id="tx_cart.variants-select.choose">
-                <source>Please choose ...</source>
-            </trans-unit>
 
             <trans-unit id="tx_cart.history_back">
                 <source>back</source>
@@ -327,33 +190,6 @@
                 <source>This shipping method is not available.</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart.controller.order.action.payment_success.successfully_paid">
-                <source>The order was successfully paid.</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.controller.order.action.payment_success.error_occured">
-                <source>An error occurred while updating the order.</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.controller.order.action.payment_success.access_denied">
-                <source>Access denied!</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.controller.order.action.payment_success.thank_you">
-                <source>Thank you for your order.</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.controller.order.action.payment_success.thank_you_order_number">
-                <source>Your order number is: %1$s</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.controller.order.action.payment_cancel.successfully_canceled">
-                <source>The order has been canceled.</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.controller.order.action.payment_cancel.error_occured">
-                <source>An error occurred while updating the order.</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.controller.order.action.payment_cancel.access_denied">
-                <source>Access denied!</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.controller.order.action.payment_cancel.thank_you">
-                <source>Thank you.</source>
-            </trans-unit>
             <trans-unit id="tx_cart.controller.order.action.generate_number_action.order.success">
                 <source>The generated order number is: %s.</source>
             </trans-unit>
@@ -379,9 +215,6 @@
                 <source>The shipping was successfully updated.</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart.controller.order.actions">
-                <source>Actions</source>
-            </trans-unit>
             <trans-unit id="tx_cart.controller.order.action.show">
                 <source>Show</source>
             </trans-unit>
@@ -455,35 +288,11 @@
                 <source>Your order number is: %1$s</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart_domain_model_order_item">
-                <source>Order</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.palettes.numbers">
-                <source>Order and Invoice Number</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.palettes.purchaser">
-                <source>Purchaser</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.palettes.addresses">
-                <source>Addresses</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.palettes.price">
-                <source>Price</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.palettes.payment">
-                <source>Payment</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.palettes.shipping">
-                <source>Shipping</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.fe_user">
-                <source>User</source>
+            <trans-unit id="tx_cart_domain_model_order_item.order_date">
+                <source>Order Date</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.order_number">
                 <source>Order Number</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.order_date">
-                <source>Order Date</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.invoice_number">
                 <source>Invoice Number</source>
@@ -503,12 +312,6 @@
             <trans-unit id="tx_cart_domain_model_order_item.billing_address">
                 <source>Billing Address</source>
             </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.gross">
-                <source>Price (gross)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.net">
-                <source>Price (net)</source>
-            </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.total_gross">
                 <source>Total Price (Gross)</source>
             </trans-unit>
@@ -520,24 +323,6 @@
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.cart_total_price">
                 <source>Total Price</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.additional_data">
-                <source>Additional Data</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.order_pdfs">
-                <source>Order PDFs</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.invoice_pdfs">
-                <source>Invoice PDFs</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.order_tax">
-                <source>Order Tax</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.order_total_tax">
-                <source>Order Total Tax</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.order_product">
-                <source>Order Product</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.order_order">
                 <source>Order</source>
@@ -562,9 +347,6 @@
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.items">
                 <source>Ordered items</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.crdate">
-                <source>Order Date</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.comment">
                 <source>Customer comment</source>
@@ -597,30 +379,8 @@
                 <source>You have to agree to the privacy policy.</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart_domain_model_order_tax">
-                <source>Order Tax</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_tax.name">
-                <source>Name</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_tax.value">
-                <source>Value</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_tax.calc">
-                <source>Calc</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_tax.sum">
-                <source>Sum</source>
-            </trans-unit>
-
-            <trans-unit id="tx_cart_domain_model_order_product">
-                <source>Order Product</source>
-            </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_product.count">
                 <source>Count</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.price.group">
-                <source>Price</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_product.discount">
                 <source>Discount</source>
@@ -631,43 +391,9 @@
             <trans-unit id="tx_cart_domain_model_order_product.net">
                 <source>Net</source>
             </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.additional_data">
-                <source>Additional Data</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_product.order_product_additional">
-                <source>Order Product Additional</source>
-            </trans-unit>
-
-            <trans-unit id="tx_cart_domain_model_order_productadditional">
-                <source>Order Product Additional</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_productadditional.additional_type">
-                <source>Type</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_productadditional.additional_key">
-                <source>Key</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_productadditional.additional_value">
-                <source>Value</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_productadditional.additional_data">
-                <source>Data</source>
-            </trans-unit>
 
             <trans-unit id="tx_cart_domain_model_order_shipping">
                 <source>Shipping</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_shipping.name">
-                <source>Name</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_shipping.net">
-                <source>Price (net)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_shipping.gross">
-                <source>Price (gross)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_shipping.tax">
-                <source>Tax</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_shipping.status">
                 <source>Status</source>
@@ -691,18 +417,6 @@
             <trans-unit id="tx_cart_domain_model_order_payment">
                 <source>Payment</source>
             </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_payment.name">
-                <source>Name</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_payment.net">
-                <source>Price (net)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_payment.gross">
-                <source>Price (gross)</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_payment.tax">
-                <source>Tax</source>
-            </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_payment.status">
                 <source>Status</source>
             </trans-unit>
@@ -722,9 +436,6 @@
                 <source>canceled</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart_domain_model_order_address">
-                <source>Order Address</source>
-            </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_address.title">
                 <source>Title</source>
             </trans-unit>
@@ -778,52 +489,6 @@
                 <source>Order receipt - %s</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart.module.productController.listAction.header">
-                <source>Product Listing</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.module.productController.showAction.header">
-                <source>Product Show</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.module.beVariantAttributeController.listAction.header">
-                <source>Variant Set Listing</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.module.beVariantAttributeController.showAction.header">
-                <source>Variant Set Show</source>
-            </trans-unit>
-
-            <trans-unit id="tx_cart.module.action.filter">
-                <source>Filter List</source>
-            </trans-unit>
-
-            <trans-unit id="tx_cart.tax_class">
-                <source>Tax Class</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.tax_class.1">
-                <source>normal</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.tax_class.2">
-                <source>reduced</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.tax_class.3">
-                <source>free</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.tax_vat">
-                <source>VAT</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.tax_vat.value">
-                <source>VAT (%s %%)</source>
-            </trans-unit>
-
-            <trans-unit id="tx_cart.plugin.form.submit">
-                <source>Add to cart</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.plugin.form.submit.success">
-                <source>The product has been added to your shopping cart.</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.plugin.form.submit.error">
-                <source>The product could not be added to the shopping cart.</source>
-            </trans-unit>
-
             <trans-unit id="tx_cart_domain_model_cart_cart.net">
                 <source>Price (net)</source>
             </trans-unit>
@@ -831,12 +496,6 @@
                 <source>Price (gross)</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart_domain_model_coupon">
-                <source>Coupon</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_coupon.code">
-                <source>Coupon Code</source>
-            </trans-unit>
             <trans-unit id="tx_cart_domain_model_coupon.code.not_useable">
                 <source>Coupon Code is not useable.</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -574,6 +574,15 @@
             <trans-unit id="tx_cart.backend.filter.end_date">
                 <source>End Date</source>
             </trans-unit>
+            <trans-unit id="tx_cart.backend.filter.no_results">
+                <source>No results for this filter</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.page_without_datasets.title">
+                <source>This page does not contain any order items.</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.page_without_datasets.instruction">
+                <source>Please select a page where order items are stored.</source>
+            </trans-unit>
 
         </body>
     </file>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -518,6 +518,13 @@
                 <source>The product was added to cart.</source>
             </trans-unit>
 
+            <trans-unit id="tx_cart.previousStep">
+                <source>Previous step</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.nextStep">
+                <source>Next step</source>
+            </trans-unit>
+
             <trans-unit id="tx_cart.backend.order.title">
                 <source>Order view for #%1$s (%2$s)</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -127,25 +127,6 @@
                 <source>Discount (gross)</source>
             </trans-unit>
 
-            <trans-unit id="filter">
-                <source>filter</source>
-            </trans-unit>
-            <trans-unit id="filterCustomer">
-                <source>Customer</source>
-            </trans-unit>
-            <trans-unit id="filterOrderNumber">
-                <source>Order Number</source>
-            </trans-unit>
-            <trans-unit id="filterInvoiceNumber">
-                <source>Invoice Number</source>
-            </trans-unit>
-            <trans-unit id="filterStartDate">
-                <source>Start Date</source>
-            </trans-unit>
-            <trans-unit id="filterEndDate">
-                <source>End Date</source>
-            </trans-unit>
-
             <trans-unit id="tx_cart.format.date">
                 <source>Y-m-d</source>
             </trans-unit>
@@ -315,9 +296,6 @@
             <trans-unit id="tx_cart_domain_model_order_item.total_gross">
                 <source>Total Price (Gross)</source>
             </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.total_net">
-                <source>Total Price (Net)</source>
-            </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.cart_price">
                 <source>Price</source>
             </trans-unit>
@@ -345,11 +323,8 @@
             <trans-unit id="tx_cart_domain_model_order_item.order_payment.method">
                 <source>Method</source>
             </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.items">
-                <source>Ordered items</source>
-            </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.comment">
-                <source>Customer comment</source>
+                <source>Comment</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.accept_terms_and_conditions">
                 <source>I have read the general terms and conditions agree to them.</source>
@@ -545,6 +520,59 @@
 
             <trans-unit id="tx_cart.backend.order.title">
                 <source>Order view for #%1$s (%2$s)</source>
+            </trans-unit>
+
+            <trans-unit id="tx_cart.backend.order.address.first_name">
+                <source>First name</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.order.address.last_name">
+                <source>Last name</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.order.address.company">
+                <source>Company</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.order.order_number">
+                <source>Order Number</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.order.order_date">
+                <source>Order Date</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.order.invoice_number">
+                <source>Invoice Number</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.order.invoice_date">
+                <source>Invoice Date</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.order.total_gross">
+                <source>Total Price (Gross)</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.order.total_net">
+                <source>Total Price (Net)</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.order.comment">
+                <source>Customer comment</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.order.items">
+                <source>Ordered items</source>
+            </trans-unit>
+
+            <trans-unit id="tx_cart.backend.filter">
+                <source>Filter</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.filter.customer">
+                <source>Customer</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.filter.order_number">
+                <source>Order Number</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.filter.invoice_number">
+                <source>Invoice Number</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.filter.start_date">
+                <source>Start Date</source>
+            </trans-unit>
+            <trans-unit id="tx_cart.backend.filter.end_date">
+                <source>End Date</source>
             </trans-unit>
 
         </body>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -3,7 +3,6 @@
     <file source-language="en" datatype="plaintext" original="messages" date="020-11-20T08:10:00Z" product-name="cart">
         <header/>
         <body>
-
             <trans-unit id="tx_cart.module.main">
                 <source>Shopping Cart</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -4,18 +4,18 @@
         <header/>
         <body>
 
-            <trans-unit id="tcarecords-pages-contains.cart_coupons">
-                <source>Cart: Coupons</source>
+            <trans-unit id="tx_cart.module.main">
+                <source>Shopping Cart</source>
             </trans-unit>
-            <trans-unit id="tcarecords-pages-contains.cart_orders">
-                <source>Cart: Orders</source>
+            <trans-unit id="tx_cart.module.orders">
+                <source>Orders</source>
             </trans-unit>
 
             <trans-unit id="tx_cart.plugin.cart.title">
                 <source>Cart: Cart</source>
             </trans-unit>
             <trans-unit id="tx_cart.plugin.cart.description">
-                <source>shows complete order form</source>
+                <source>Shows complete order form</source>
             </trans-unit>
 
             <trans-unit id="widget_group.cart">
@@ -26,9 +26,6 @@
             </trans-unit>
             <trans-unit id="dashboard.widgets.payment_paid_shipping_open.description">
                 <source>List of Paid but not Shipped Orders</source>
-            </trans-unit>
-            <trans-unit id="dashboard.widgets.orders_per_day.chart.dataSet.0">
-                <source>Total Orders</source>
             </trans-unit>
             <trans-unit id="dashboard.widgets.orders_per_day.title">
                 <source>Orders per Day</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -3,21 +3,6 @@
     <file source-language="en" datatype="plaintext" original="messages" date="2022-05-31T19:53:00Z" product-name="cart">
         <header/>
         <body>
-
-            <trans-unit id="tx_cart.typoscript.default_configuration">
-                <source>Shopping Cart - Example Configuration</source>
-            </trans-unit>
-
-            <trans-unit id="tx_cart.module.main">
-                <source>Shopping Cart</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.module.orders">
-                <source>Orders</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.module.coupons">
-                <source>Coupons</source>
-            </trans-unit>
-
             <trans-unit id="tx_cart.plugin.mini_cart">
                 <source>Cart: Mini-Cart</source>
             </trans-unit>
@@ -27,19 +12,10 @@
             <trans-unit id="tx_cart.plugin.currency">
                 <source>Cart: Currency Selector</source>
             </trans-unit>
-            <trans-unit id="tx_cart.plugin.product">
-                <source>Cart: Product</source>
-            </trans-unit>
             <trans-unit id="tx_cart.plugin.order">
                 <source>Cart: Orders</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart.flexform.productId">
-                <source>Product Id</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.flexform.cartPageId">
-                <source>Cart Page Id</source>
-            </trans-unit>
             <trans-unit id="tx_cart.flexform.seller.email_from_name">
                 <source>Sender email name for email to the Seller</source>
             </trans-unit>
@@ -49,17 +25,17 @@
             <trans-unit id="tx_cart.flexform.seller.email_to_address">
                 <source>Receiver email addresses (seperated by comma) for email to the Seller</source>
             </trans-unit>
-            <trans-unit id="tx_cart.flexform.seller.email_bcc_address">
+            <trans-unit id="tx_cart.flexform.seller.email_cc_address">
                 <source>CC email addresses (seperated by comma) for email to the Seller</source>
             </trans-unit>
-            <trans-unit id="tx_cart.flexform.seller.email_bcc_address.description">
-                <source>The recipients of e-mails sent to one or more e-mail addresses separated by commas and listed in the so-called CC (Carbon Copy) field will receive a copy of the sent e-mail.</source>
+            <trans-unit id="tx_cart.flexform.seller.email_cc_address.description">
+                <source>The recipients of emails sent to one or more email addresses separated by commas and listed in the so-called CC (Carbon Copy) field will receive a copy of the sent email.</source>
             </trans-unit>
             <trans-unit id="tx_cart.flexform.seller.email_bcc_address">
                 <source>BCC email addresses (seperated by comma) for email to the Seller</source>
             </trans-unit>
             <trans-unit id="tx_cart.flexform.seller.email_bcc_address.description">
-                <source>The recipients of e-mails sent to one or more e-mail addresses separated by commas and listed in the so-called BCC (Blind Carbon Copy) field will receive a copy of the sent e-mail without their address being visible to the other specified recipients. (Source: Wikipedia)</source>
+                <source>The recipients of emails sent to one or more email addresses separated by commas and listed in the so-called BCC (Blind Carbon Copy) field will receive a copy of the sent email without their address being visible to the other specified recipients. (Source: Wikipedia)</source>
             </trans-unit>
             <trans-unit id="tx_cart.flexform.buyer.email_from_name">
                 <source>Sender email name for email to the Buyer</source>
@@ -71,13 +47,13 @@
                 <source>CC email addresses (seperated by comma) for email to the Buyer</source>
             </trans-unit>
             <trans-unit id="tx_cart.flexform.buyer.email_cc_address.description">
-                <source>The recipients of e-mails sent to one or more e-mail addresses separated by commas and listed in the so-called CC (Carbon Copy) field will receive a copy of the sent e-mail.</source>
+                <source>The recipients of emails sent to one or more email addresses separated by commas and listed in the so-called CC (Carbon Copy) field will receive a copy of the sent email.</source>
             </trans-unit>
             <trans-unit id="tx_cart.flexform.buyer.email_bcc_address">
                 <source>BCC email addresses (seperated by comma) for email to the Buyer</source>
             </trans-unit>
             <trans-unit id="tx_cart.flexform.buyer.email_bcc_address.description">
-                <source>The recipients of e-mails sent to one or more e-mail addresses separated by commas and listed in the so-called BCC (Blind Carbon Copy) field will receive a copy of the sent e-mail without their address being visible to the other specified recipients. (Source: Wikipedia)</source>
+                <source>The recipients of emails sent to one or more email addresses separated by commas and listed in the so-called BCC (Blind Carbon Copy) field will receive a copy of the sent email without their address being visible to the other specified recipients. (Source: Wikipedia)</source>
             </trans-unit>
             <trans-unit id="tx_cart.flexform.buyer.email_reply_to_address">
                 <source>Reply To email address for email to the Buyer</source>
@@ -99,14 +75,8 @@
                 <source>free</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart_domain_model_order_item">
-                <source>Order</source>
-            </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.palettes.numbers">
                 <source>Order and Invoice Number</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.palettes.purchaser">
-                <source>Purchaser</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.palettes.addresses">
                 <source>Addresses</source>
@@ -116,15 +86,6 @@
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.palettes.total_price">
                 <source>Total Price</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.palettes.payment">
-                <source>Payment</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.palettes.shipping">
-                <source>Shipping</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.palettes.documents">
-                <source>Documents</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.fe_user">
                 <source>User</source>
@@ -149,15 +110,6 @@
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.delivery_date">
                 <source>Delivery Note Date</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.first_name">
-                <source>Firstname</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.last_name">
-                <source>Lastname</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_item.email">
-                <source>Email</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.billing_address">
                 <source>Billing Address</source>
@@ -229,6 +181,9 @@
                 <source>Payment</source>
             </trans-unit>
 
+            <trans-unit id="tx_cart_domain_model_order_address">
+                <source>Order Address</source>
+            </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_address.record_type">
                 <source>Record Type</source>
             </trans-unit>
@@ -500,9 +455,6 @@
             <trans-unit id="tx_cart_domain_model_order_payment.note">
                 <source>Note</source>
             </trans-unit>
-            <trans-unit id="tx_cart_domain_model_order_payment.transactions">
-                <source>Transactions</source>
-            </trans-unit>
 
             <trans-unit id="tx_cart_domain_model_order_transaction">
                 <source>Transaction</source>
@@ -552,10 +504,6 @@
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_taxclass.calc">
                 <source>Calc</source>
-            </trans-unit>
-
-            <trans-unit id="tx_cart_domain_model_order_address">
-                <source>Order Address</source>
             </trans-unit>
 
             <trans-unit id="tx_cart_domain_model_coupon">
@@ -613,15 +561,8 @@
                 <source>Number of Coupons used</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart.plugin.products.action.product.flexform">
-                <source>Flexform</source>
-            </trans-unit>
-
             <trans-unit id="tx_cart_domain_model_tag">
                 <source>Tag</source>
-            </trans-unit>
-            <trans-unit id="tx_cart_domain_model_tags">
-                <source>Tags</source>
             </trans-unit>
             <trans-unit id="tx_cart_domain_model_tag.title">
                 <source>Title</source>
@@ -631,21 +572,15 @@
                 <source>Cart Session</source>
             </trans-unit>
 
-            <trans-unit id="tx_cart.settings.allowed_countries.de">
-                <source>Germany</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.settings.allowed_countries.at">
-                <source>Austria</source>
-            </trans-unit>
-            <trans-unit id="tx_cart.settings.allowed_countries.ch">
-                <source>Switzerland</source>
-            </trans-unit>
-
             <trans-unit id="pages.doktype.181">
                 <source>Cart: Cart</source>
             </trans-unit>
-            <trans-unit id="pages.doktype.182">
-                <source>Cart: Product</source>
+
+            <trans-unit id="tcarecords-pages-contains.cart_coupons">
+                <source>Cart: Coupons</source>
+            </trans-unit>
+            <trans-unit id="tcarecords-pages-contains.cart_orders">
+                <source>Cart: Orders</source>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Partials/Backend/Order/Filter/List.html
+++ b/Resources/Private/Partials/Backend/Order/Filter/List.html
@@ -5,7 +5,7 @@
     <div class="row">
         <div class="form-group col col-sm-4">
             <label for="searchCustomer" class="form-label">
-                <f:translate key="filterCustomer"/>
+                <f:translate key="tx_cart.backend.filter.customer"/>
             </label>
             <f:form.textfield property="customer" id="searchCustomer"
                               class="form-control"
@@ -16,7 +16,7 @@
     <div class="row">
         <div class="form-group col col-sm-3">
             <label for="searchOrderNumber" class="form-label">
-                <f:translate key="filterOrderNumber"/>
+                <f:translate key="tx_cart.backend.filter.order_number"/>
             </label>
             <f:form.textfield property="orderNumber" id="searchOrderNumber"
                               class="form-control"
@@ -24,7 +24,7 @@
         </div>
         <div class="form-group col col-sm-3">
             <label for="searchOrderDateStart" class="form-label">
-                <f:translate key="filterStartDate"/>
+                <f:translate key="tx_cart.backend.filter.start_date"/>
             </label>
             <f:form.textfield
                     name="orderDateStart"
@@ -40,7 +40,7 @@
         </div>
         <div class="form-group col col-sm-3">
             <label for="searchOrderDateEnd" class="form-label">
-                <f:translate key="filterEndDate"/>
+                <f:translate key="tx_cart.backend.filter.end_date"/>
             </label>
             <f:form.textfield
                     name="orderDateEnd"
@@ -60,7 +60,7 @@
     <div class="row">
         <div class="form-group col col-sm-3">
             <label for="searchInvoiceNumber" class="form-label">
-                <f:translate key="filterInvoiceNumber"/>
+                <f:translate key="tx_cart.backend.filter.invoice_number"/>
             </label>
             <f:form.textfield property="invoiceNumber" id="searchInvoiceNumber"
                               class="form-control"
@@ -68,7 +68,7 @@
         </div>
         <div class="form-group col col-sm-3">
             <label for="searchInvoiceDateStart" class="form-label">
-                <f:translate key="filterStartDate"/>
+                <f:translate key="tx_cart.backend.filter.start_date"/>
             </label>
             <f:form.textfield
                     name="searchInvoiceDateStart"
@@ -84,7 +84,7 @@
         </div>
         <div class="form-group col col-sm-3">
             <label for="searchInvoiceDateEnd" class="form-label">
-                <f:translate key="filterEndDate"/>
+                <f:translate key="tx_cart.backend.filter.end_date"/>
             </label>
             <f:form.textfield
                     name="invoiceDateEnd"
@@ -120,6 +120,6 @@
                            value="{searchArguments.paymentStatus}"/>
         </div>
     </div>
-    <f:form.submit value="{f:translate(key: 'filter')}" class="my-3 btn btn-default"/>
+    <f:form.submit value="{f:translate(key: 'tx_cart.backend.filter')}" class="my-3 btn btn-default"/>
 </f:form>
 </html>

--- a/Resources/Private/Templates/Backend/Order/Order/List.html
+++ b/Resources/Private/Templates/Backend/Order/Order/List.html
@@ -7,78 +7,99 @@
 
 <f:section name="Content">
     <div class="cart-list">
-    <f:render partial="Backend/Order/Filter/List"
-              arguments="{searchArguments: searchArguments, action: 'list', paymentStatus: paymentStatus, shippingStatus: shippingStatus}"/>
+        <f:if condition="!{orderItems} && !{searchArguments}">
+            <f:then>
+                <f:comment>
+                    Do not show the filter if the page has no `orderItems` and no ``searchArguments`.
+                    The searchArguments are needed as condition as otherwise the filters will not be shown when the
+                    search results in zero order items.
+                </f:comment>
+            </f:then>
+            <f:else>
+                <f:render partial="Backend/Order/Filter/List"
+                          arguments="{searchArguments: searchArguments, action: 'list', paymentStatus: paymentStatus, shippingStatus: shippingStatus}"/>
+            </f:else>
+        </f:if>
 
-    <div class="clear"></div>
 
-    <f:if condition="{orderItems}">
-        <f:then>
-            <div class="table-fit">
-                <table class="table table-striped table-hover">
-                    <thead>
-                    <tr>
-                        <th>
-                            <f:translate key="tx_cart.backend.order.address.first_name"/>
-                        </th>
-                        <th>
-                            <f:translate key="tx_cart.backend.order.address.last_name"/>
-                        </th>
-                        <th>
-                            <f:translate key="tx_cart.backend.order.address.company"/>
-                        </th>
-                        <th>
-                            <f:translate key="tx_cart.backend.order.order_number"/>
-                        </th>
-                        <th>
-                            <f:translate key="tx_cart.backend.order.order_date"/>
-                        </th>
-                        <th>
-                            <f:translate key="tx_cart.backend.order.invoice_number"/>
-                        </th>
-                        <th>
-                            <f:translate key="tx_cart.backend.order.invoice_date"/>
-                        </th>
-                        <th>
-                            <f:translate key="tx_cart.backend.order.total_gross"/>
-                        </th>
-                        <th>
-                            <f:translate key="tx_cart.backend.order.total_net"/>
-                        </th>
-                        <th>
-                            <f:translate key="tx_cart_domain_model_order_payment"/>
-                            <br/>(
-                            <f:translate key="tx_cart_domain_model_order_payment.status"/>
-                            )
-                        </th>
-                        <th>
-                            <f:translate key="tx_cart_domain_model_order_shipping"/>
-                            <br/>(
-                            <f:translate key="tx_cart_domain_model_order_shipping.status"/>
-                            )
-                        </th>
-                        <th>
-                            &nbsp;
-                        </th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <f:for each="{paginator.paginatedItems}" as="orderItem">
-                        <f:cycle values="{0: 'even', 1: 'odd'}" as="cycle">
-                            <f:render partial="Backend/Order/List/Item"
-                                      arguments="{orderItem: orderItem, cycle:cycle, arguments: arguments, pdfRendererInstalled: pdfRendererInstalled}"/>
-                        </f:cycle>
-                    </f:for>
-                    </tbody>
-                </table>
-            </div>
-            <f:render partial="Utility/Paginator"
-                      arguments="{pagination: pagination, pages: pages, paginator: paginator}"/>
-        </f:then>
-        <f:else>
-            Select a Page where Order Item Dataset are saved.
-        </f:else>
-    </f:if>
+        <div class="clear"></div>
+
+        <f:if condition="{orderItems}">
+            <f:then>
+                <div class="table-fit">
+                    <table class="table table-striped table-hover">
+                        <thead>
+                        <tr>
+                            <th>
+                                <f:translate key="tx_cart.backend.order.address.first_name"/>
+                            </th>
+                            <th>
+                                <f:translate key="tx_cart.backend.order.address.last_name"/>
+                            </th>
+                            <th>
+                                <f:translate key="tx_cart.backend.order.address.company"/>
+                            </th>
+                            <th>
+                                <f:translate key="tx_cart.backend.order.order_number"/>
+                            </th>
+                            <th>
+                                <f:translate key="tx_cart.backend.order.order_date"/>
+                            </th>
+                            <th>
+                                <f:translate key="tx_cart.backend.order.invoice_number"/>
+                            </th>
+                            <th>
+                                <f:translate key="tx_cart.backend.order.invoice_date"/>
+                            </th>
+                            <th>
+                                <f:translate key="tx_cart.backend.order.total_gross"/>
+                            </th>
+                            <th>
+                                <f:translate key="tx_cart.backend.order.total_net"/>
+                            </th>
+                            <th>
+                                <f:translate key="tx_cart_domain_model_order_payment"/>
+                                <br/>(
+                                <f:translate key="tx_cart_domain_model_order_payment.status"/>
+                                )
+                            </th>
+                            <th>
+                                <f:translate key="tx_cart_domain_model_order_shipping"/>
+                                <br/>(
+                                <f:translate key="tx_cart_domain_model_order_shipping.status"/>
+                                )
+                            </th>
+                            <th>
+                                &nbsp;
+                            </th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <f:for each="{paginator.paginatedItems}" as="orderItem">
+                            <f:cycle values="{0: 'even', 1: 'odd'}" as="cycle">
+                                <f:render partial="Backend/Order/List/Item"
+                                          arguments="{orderItem: orderItem, cycle:cycle, arguments: arguments, pdfRendererInstalled: pdfRendererInstalled}"/>
+                            </f:cycle>
+                        </f:for>
+                        </tbody>
+                    </table>
+                </div>
+                <f:render partial="Utility/Paginator"
+                          arguments="{pagination: pagination, pages: pages, paginator: paginator}"/>
+            </f:then>
+            <f:else>
+                <f:if condition="{searchArguments}">
+                    <f:then>
+                        <f:translate key="tx_cart.backend.filter.no_results"/>
+                    </f:then>
+                    <f:else>
+                        <h2><f:translate key="tx_cart.backend.page_without_datasets.title"/></h2>
+                        <h4><f:translate key="tx_cart.backend.page_without_datasets.instruction"/></h4>
+                    </f:else>
+                </f:if>
+
+            </f:else>
+        </f:if>
     </div>
 </f:section>
 </html>

--- a/Resources/Private/Templates/Backend/Order/Order/List.html
+++ b/Resources/Private/Templates/Backend/Order/Order/List.html
@@ -19,31 +19,31 @@
                     <thead>
                     <tr>
                         <th>
-                            <f:translate key="tx_cart_domain_model_order_address.first_name"/>
+                            <f:translate key="tx_cart.backend.order.address.first_name"/>
                         </th>
                         <th>
-                            <f:translate key="tx_cart_domain_model_order_address.last_name"/>
+                            <f:translate key="tx_cart.backend.order.address.last_name"/>
                         </th>
                         <th>
-                            <f:translate key="tx_cart_domain_model_order_address.company"/>
+                            <f:translate key="tx_cart.backend.order.address.company"/>
                         </th>
                         <th>
-                            <f:translate key="tx_cart_domain_model_order_item.order_number"/>
+                            <f:translate key="tx_cart.backend.order.order_number"/>
                         </th>
                         <th>
-                            <f:translate key="tx_cart_domain_model_order_item.order_date"/>
+                            <f:translate key="tx_cart.backend.order.order_date"/>
                         </th>
                         <th>
-                            <f:translate key="tx_cart_domain_model_order_item.invoice_number"/>
+                            <f:translate key="tx_cart.backend.order.invoice_number"/>
                         </th>
                         <th>
-                            <f:translate key="tx_cart_domain_model_order_item.invoice_date"/>
+                            <f:translate key="tx_cart.backend.order.invoice_date"/>
                         </th>
                         <th>
-                            <f:translate key="tx_cart_domain_model_order_item.total_gross"/>
+                            <f:translate key="tx_cart.backend.order.total_gross"/>
                         </th>
                         <th>
-                            <f:translate key="tx_cart_domain_model_order_item.total_net"/>
+                            <f:translate key="tx_cart.backend.order.total_net"/>
                         </th>
                         <th>
                             <f:translate key="tx_cart_domain_model_order_payment"/>

--- a/Resources/Private/Templates/Backend/Order/Order/Show.html
+++ b/Resources/Private/Templates/Backend/Order/Order/Show.html
@@ -27,7 +27,7 @@
             <div class="card-container mb-3">
                 <div class="card p-4">
                     <h4>
-                        <f:translate key="tx_cart_domain_model_order_item.comment"/>
+                        <f:translate key="tx_cart.backend.order.comment"/>
                     </h4>
                     {orderItem.comment -> f:sanitize.html()}
                 </div>
@@ -36,7 +36,7 @@
         <div class="card-container">
             <div class="card p-4">
                 <h4>
-                    <f:translate key="tx_cart_domain_model_order_item.items"/>
+                    <f:translate key="tx_cart.backend.order.items"/>
                 </h4>
                 <f:render partial="Backend/Order/Show/Cart" arguments="{orderItem: orderItem}"/>
             </div>


### PR DESCRIPTION
* Every language files has it's clear domain.
* No unused entries in the files.
* Some labels which are used in the backend are used from the `locallang.xlf` but have their own entries which are namespaced with e.g. `tx_cart.backend.*`.

This PR build on #465. I will rebase it after #465 was merged.

Fixes #471 