### PR TITLE
[TASK] Switch input type to `number` for quantity

### DIFF
--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -15,7 +15,7 @@ return (new \PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@DoctrineAnnotation' => true,
-        '@PER' => true,
+        '@PER-CS' => true,
         'array_syntax' => ['syntax' => 'short'],
         'cast_spaces' => ['space' => 'none'],
         'concat_space' => ['spacing' => 'one'],
@@ -23,7 +23,6 @@ return (new \PhpCsFixer\Config())
         'declare_parentheses' => true,
         'dir_constant' => true,
         'function_to_constant' => ['functions' => ['get_called_class', 'get_class', 'get_class_this', 'php_sapi_name', 'phpversion', 'pi']],
-        'function_typehint_space' => true,
         'modernize_strpos' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,
@@ -58,6 +57,7 @@ return (new \PhpCsFixer\Config())
         'single_space_around_construct' => true,
         'single_line_comment_style' => ['comment_types' => ['hash']],
         'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'type_declaration_spaces' => true,
         'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
         'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
     ]);

--- a/Classes/Service/MailHandler.php
+++ b/Classes/Service/MailHandler.php
@@ -46,8 +46,7 @@ class MailHandler implements SingletonInterface
         LogManager $logManager,
         ConfigurationManager $configurationManager,
         MailerInterface $mailer
-    )
-    {
+    ) {
         $this->logManager = $logManager;
         $this->configurationManager = $configurationManager;
         $this->mailer = $mailer;

--- a/Resources/Private/Partials/Cart/ProductForm/ProductList.html
+++ b/Resources/Private/Partials/Cart/ProductForm/ProductList.html
@@ -19,7 +19,11 @@
             </span>
         </td>
         <td class="col-md-1 text-right">
-            <f:form.textfield class="form-control form-control-inline" type="text" value="{product.quantity}" name="quantities[{product.id}]"/>
+            <f:form.textfield
+                class="form-control form-control-inline"
+                type="number"
+                alue="{product.quantity}"
+                name="quantities[{product.id}]"/>
         </td>
         <td class="col-md-2 text-right">
             <f:if condition="{product.quantityIsInRange}">
@@ -68,7 +72,7 @@
                     <div class="qty-wrapper">
                         <f:form.textfield
                                 class="form-control form-control-inline"
-                                type="text"
+                                type="number"
                                 value="{variant.quantity}"
                                 name="quantities{cart:fieldName(variant:variant)}"/>
                     </div>


### PR DESCRIPTION
Form input fields which are used in the FE to
enter the quantity of products used
`type="text"`. These fields now use
`type="number"` instead.

Fixes #311