### PR TITLE
[TASK] Reimplement `TitleTagViewHelper`

### DIFF
--- a/Classes/PageTitle/PageTitleProvider.php
+++ b/Classes/PageTitle/PageTitleProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package extcode/cart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Extcode\Cart\PageTitle;
+
+use TYPO3\CMS\Core\PageTitle\AbstractPageTitleProvider;
+
+class PageTitleProvider extends AbstractPageTitleProvider
+{
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/Classes/ViewHelpers/TitleTagViewHelper.php
+++ b/Classes/ViewHelpers/TitleTagViewHelper.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package extcode/cart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Extcode\Cart\ViewHelpers;
+
+use Extcode\Cart\PageTitle\PageTitleProvider;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * ViewHelper to render the page title
+ */
+class TitleTagViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('pageTitle', 'String', 'The page title');
+    }
+
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        $pageTitle = $arguments['pageTitle'] ?? '';
+        if ($pageTitle !== '') {
+            GeneralUtility::makeInstance(PageTitleProvider::class)->setTitle($pageTitle);
+        }
+    }
+}

--- a/Documentation/Changelog/9.0/Breaking-480-RefactoredPageTitleViewhelper.rst
+++ b/Documentation/Changelog/9.0/Breaking-480-RefactoredPageTitleViewhelper.rst
@@ -1,0 +1,41 @@
+.. include:: ../../Includes.txt
+
+===============================================
+Breaking: #480 - Refactored PageTitleViewhelper
+===============================================
+
+See :issue:`480`
+
+Description
+===========
+
+The existing `TitleTagViewHelper` was removed because it stopped working after
+TYPO3 v10. The new ViewHelper adds the same functionality but its usage is
+different.
+
+Affected Installations
+======================
+
+The ViewHelper was not used in EXT:cart itself. But other extensions as e.g.
+EXT:cart_products used it. Overwrites and own implementations of templates which
+used `<cart:titleTag>` need adaption.
+
+Migration
+=========
+
+Migrate the old usage of the ViewHelper as shown below
+
+.. code-block:: html
+   :caption: e.g. overwrite of EXT:cart_products/Resources/Private/Templates/Product/Show.html
+
+   <!-- OLD IMPLEMENTATION -->
+   <cart:format.nothing>
+       <cart:titleTag>
+           <f:format.htmlentitiesDecode>{product.title}</f:format.htmlentitiesDecode>
+       </cart:titleTag>
+   </cart:format.nothing>
+
+   <!-- NEW IMPLEMENTATION -->
+   <cart:titleTag pageTitle="{product.title}" />
+
+.. index:: Template, Frontend

--- a/ext_typoscript_setup.typoscript
+++ b/ext_typoscript_setup.typoscript
@@ -18,3 +18,10 @@ module.tx_cart {
         }
     }
 }
+
+config.pageTitleProviders {
+    cart {
+        provider = Extcode\Cart\PageTitle\PageTitleProvider
+        before = record
+    }
+}


### PR DESCRIPTION
Reimplements a ViewHelper to set the page title 
which can be used by other extensions for EXT:cart.

The implementation is copied from
`EXT:sf_event_mgt`. 

Compared to an implementation without a ViewHelper 
(the title could also be set within the controller) this 
approach enables other integrators to easily adapt
 the page title by simply  adding another value to the 
argument `pageTitle`.

This is a preparation for https://github.com/extcode/cart_products/issues/132

Fixes #480