### PR TITLE
[TASK] Add `return` statement to all `redirect()`

### DIFF
--- a/Classes/Controller/Backend/Order/DocumentController.php
+++ b/Classes/Controller/Backend/Order/DocumentController.php
@@ -39,7 +39,7 @@ class DocumentController extends ActionController
         $this->itemRepository = $itemRepository;
     }
 
-    public function createAction(Item $orderItem, string $pdfType): void
+    public function createAction(Item $orderItem, string $pdfType): ResponseInterface
     {
         $getNumber = 'get' . ucfirst($pdfType) . 'Number';
 
@@ -73,7 +73,7 @@ class DocumentController extends ActionController
         $msg = ucfirst($pdfType) . '-PDF-Document was generated.';
         $this->addFlashMessage($msg);
 
-        $this->redirect('show', 'Backend\Order\Order', null, ['orderItem' => $orderItem]);
+        return $this->redirect('show', 'Backend\Order\Order', null, ['orderItem' => $orderItem]);
     }
 
     public function downloadAction(Item $orderItem, string $pdfType): ResponseInterface

--- a/Classes/Controller/Cart/CartController.php
+++ b/Classes/Controller/Cart/CartController.php
@@ -148,13 +148,13 @@ class CartController extends ActionController
     public function updateAction(): ResponseInterface
     {
         if (!$this->request->hasArgument('quantities')) {
-            $this->redirect('show');
+            return $this->redirect('show');
         }
 
         $updateQuantities = $this->request->getArgument('quantities');
 
         if (!is_array($updateQuantities)) {
-            $this->redirect('show');
+            return $this->redirect('show');
         }
 
         $this->restoreSession();

--- a/Classes/Controller/Cart/ProductController.php
+++ b/Classes/Controller/Cart/ProductController.php
@@ -105,7 +105,7 @@ class ProductController extends ActionController
                 true
             );
 
-            $this->redirect('show', 'Cart\Cart');
+            return $this->redirect('show', 'Cart\Cart');
         }
 
         $quantity = $this->addProductsToCart($cartProducts);

--- a/Classes/Controller/Order/OrderController.php
+++ b/Classes/Controller/Order/OrderController.php
@@ -82,7 +82,7 @@ class OrderController extends ActionController
                 '',
                 ContextualFeedbackSeverity::ERROR
             );
-            $this->redirect('list');
+            return $this->redirect('list');
         }
 
         $this->view->assign('orderItem', $orderItem);


### PR DESCRIPTION
All redirect() calls need to be "prefixed" with
`return` in TYPO3 v12 to work properly,
see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.3/Deprecation-94351-ExtextbaseStopActionException.html

Fixes #483