### PR TITLE
[TASK] Move page TSconfig inclusion

### DIFF
--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,2 +1,4 @@
+@import "EXT:cart/Configuration/TSconfig/ContentElementWizard.tsconfig"
+
 # Template path for dashboard widgets
 templates.typo3/cms-dashboard.1712899110 = extcode/cart:Resources/Private/

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -14,7 +14,6 @@ use Extcode\Cart\Controller\Cart\ShippingController;
 use Extcode\Cart\Hooks\MailAttachmentHook;
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
 use TYPO3\CMS\Core\Imaging\IconRegistry;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
@@ -104,12 +103,6 @@ foreach ($icons as $identifier => $fileName) {
         ]
     );
 }
-
-// TSconfig
-
-ExtensionManagementUtility::addPageTSConfig('
-    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:cart/Configuration/TSconfig/ContentElementWizard.tsconfig">
-');
 
 // register "cart:" namespace
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['cart'][] = 'Extcode\\Cart\\ViewHelpers';


### PR DESCRIPTION
With TYPO3 v12 the page TSconfig is automatically
loaded from `Configuration/page.tsconfig`.
Including it in `ext_localconf.php` is no longer
needed.