### PR TITLE
[TASK] Add coupon form to multi-step checkout

### DIFF
--- a/Resources/Private/Templates/Cart/Cart/ShowStep1.html
+++ b/Resources/Private/Templates/Cart/Cart/ShowStep1.html
@@ -20,6 +20,10 @@
                 <f:then>
                     <f:render partial="Cart/ProductForm" arguments="{cart:cart}"/>
 
+                    <f:if condition="{settings.showCartAction.showPartials.couponForm}">
+                        <f:render partial="Cart/CouponForm" arguments="{cart:cart}"/>
+                    </f:if>
+
                     <f:if condition="{cart.isOrderable}">
                         <div class="row">
                             <f:if condition="{previousStep}">


### PR DESCRIPTION
The coupon form was missing in the multi-step
checkout and is not added in step 1 beneath
the product list.