### PR TITLE
[BUGFIX] Add event classes to services configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,7 @@ max_line_length = 80
 # TS/JS-Files
 [*.{ts,js,mjs}]
 indent_size = 2
+
+# YAML-Files
+[*.{yaml,yml}]
+indent_size = 2

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -12,11 +12,13 @@ services:
     tags:
       - name: event.listener
         identifier: 'cart--cart--update-country'
+        event: Extcode\Cart\Event\Cart\UpdateCountryEvent
 
   Extcode\Cart\EventListener\Cart\UpdateCurrency:
     tags:
       - name: event.listener
         identifier: 'cart--cart--update-currency'
+        event: Extcode\Cart\Event\Cart\UpdateCurrency
 
   Extcode\Cart\EventListener\Mail\AttachmentFromOrderItem:
     tags:
@@ -32,40 +34,47 @@ services:
     tags:
       - name: event.listener
         identifier: 'cart--order--create--order'
+        event: Extcode\Cart\Event\Order\CreateEvent
 
   Extcode\Cart\EventListener\Order\Create\PersistOrder\Item:
     tags:
       - name: event.listener
         identifier: 'cart--order--create--persist-order--item'
+        event: Extcode\Cart\Event\Order\PersistOrderEvent
 
   Extcode\Cart\EventListener\Order\Create\PersistOrder\TaxClasses:
     tags:
       - name: event.listener
         identifier: 'cart--order--create--persist-order--tax-classes'
+        event: Extcode\Cart\Event\Order\PersistOrderEvent
         after: 'cart--order--create--persist-order--item'
 
   Extcode\Cart\EventListener\Order\Create\PersistOrder\Products:
     tags:
       - name: event.listener
         identifier: 'cart--order--create--persist-order--products'
+        event: Extcode\Cart\Event\Order\PersistOrderEvent
         after: 'cart--order--create--persist-order--tax-classes'
 
   Extcode\Cart\EventListener\Order\Create\PersistOrder\Coupons:
     tags:
       - name: event.listener
         identifier: 'cart--order--create--persist-order--coupons'
+        event: Extcode\Cart\Event\Order\PersistOrderEvent
         after: 'cart--order--create--persist-order--tax-classes'
 
   Extcode\Cart\EventListener\Order\Create\PersistOrder\Payment:
     tags:
       - name: event.listener
         identifier: 'cart--order--create--persist-order--payment'
+        event: Extcode\Cart\Event\Order\PersistOrderEvent
         after: 'cart--order--create--persist-order--tax-classes'
 
   Extcode\Cart\EventListener\Order\Create\PersistOrder\Shipping:
     tags:
       - name: event.listener
         identifier: 'cart--order--create--persist-order--shipping'
+        event: Extcode\Cart\Event\Order\PersistOrderEvent
         after: 'cart--order--create--persist-order--tax-classes'
 
   Extcode\Cart\EventListener\Order\Create\OrderNumber:
@@ -74,6 +83,7 @@ services:
     tags:
       - name: event.listener
         identifier: 'cart--order--create--order-number'
+        event: Extcode\Cart\Event\Order\NumberGeneratorEvent
         after: 'cart--order--create--order'
 
   Extcode\Cart\EventListener\Order\Create\InvoiceNumber:
@@ -82,6 +92,7 @@ services:
     tags:
       - name: event.listener
         identifier: 'cart--order--create--invoice-number'
+        event: Extcode\Cart\Event\Order\NumberGeneratorEvent
         after: 'cart--order--create--order'
 
   Extcode\Cart\EventListener\Order\Create\DeliveryNumber:
@@ -90,25 +101,32 @@ services:
     tags:
       - name: event.listener
         identifier: 'cart--order--create--delivery-number'
+        event: Extcode\Cart\Event\Order\NumberGeneratorEvent
         after: 'cart--order--create--order'
 
   Extcode\Cart\EventListener\Order\Finish\ClearCart:
     tags:
       - name: event.listener
         identifier: 'cart--order--finish--clear-cart'
+        event: Extcode\Cart\Event\Order\FinishEvent
         after: 'cart--order--finish--email'
 
   Extcode\Cart\EventListener\Order\Finish\Email:
     tags:
       - name: event.listener
         identifier: 'cart--order--finish--email'
+        event: Extcode\Cart\Event\Order\FinishEvent
 
   Extcode\Cart\EventListener\Order\Update\LogServiceUpdate:
     tags:
       - name: event.listener
         identifier: 'cart--order--update--log-service-update'
+        event: Extcode\Cart\Event\Order\UpdateServiceEvent
 
   Extcode\Cart\Service\TaxClassService:
+    public: true
+
+  Extcode\Cart\View\CartTemplateView:
     public: true
 
   querybuilder.tx_cart_domain_model_order_item:


### PR DESCRIPTION
The event classes must be added in the service configuration for the EventListener, as the events work with interfaces for and therefore cannot be resolved automatically.

Relates: #491