### PR TITLE
Replace `ParserUtility::parseTaxClasses` by DI

### DIFF
--- a/Classes/Controller/Cart/CountryController.php
+++ b/Classes/Controller/Cart/CountryController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Extcode\Cart\Controller\Cart;
 
+use Extcode\Cart\Service\TaxClassServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /*
@@ -14,6 +15,10 @@ use Psr\Http\Message\ResponseInterface;
  */
 class CountryController extends ActionController
 {
+    public function __construct(
+        protected TaxClassServiceInterface $taxClassService
+    ) {}
+
     public function updateAction(): ResponseInterface
     {
         //ToDo check country is allowed by TypoScript
@@ -22,7 +27,7 @@ class CountryController extends ActionController
 
         $this->restoreSession();
 
-        $taxClasses = $this->parserUtility->parseTaxClasses($this->configurations, $this->cart->getBillingCountry());
+        $taxClasses = $this->taxClassService->getTaxClasses($this->cart->getBillingCountry());
 
         $this->cart->setTaxClasses($taxClasses);
         $this->cart->reCalc();

--- a/Classes/Domain/Model/Cart/TaxClass.php
+++ b/Classes/Domain/Model/Cart/TaxClass.php
@@ -11,27 +11,14 @@ namespace Extcode\Cart\Domain\Model\Cart;
  * LICENSE file that was distributed with this source code.
  */
 
-class TaxClass
+final class TaxClass implements TaxClassInterface
 {
-    protected int $id;
-
-    protected string $value;
-
-    protected float $calc;
-
-    protected string $title;
-
     public function __construct(
-        int $id,
-        string $value,
-        float $calc,
-        string $title
-    ) {
-        $this->id = $id;
-        $this->value = $value;
-        $this->calc = $calc;
-        $this->title = $title;
-    }
+        private readonly int $id,
+        private readonly string $value,
+        private readonly float $calc,
+        private readonly string $title
+    ) {}
 
     public function getId(): int
     {

--- a/Classes/Domain/Model/Cart/TaxClassFactory.php
+++ b/Classes/Domain/Model/Cart/TaxClassFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Extcode\Cart\Domain\Model\Cart;
+
+/*
+ * This file is part of the package extcode/cart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Psr\Log\LoggerInterface;
+
+final class TaxClassFactory implements TaxClassFactoryInterface
+{
+    public function __construct(
+        private readonly LoggerInterface $logger
+    ) {}
+
+    public function getTaxClass(int $taxClassKey, array $taxClassValue): ?TaxClass
+    {
+        if ($this->isValidTaxClassConfig($taxClassKey, $taxClassValue)) {
+            return new TaxClass(
+                $taxClassKey,
+                $taxClassValue['value'],
+                (float)$taxClassValue['calc'],
+                $taxClassValue['name']
+            );
+        }
+
+        return null;
+    }
+
+    private function isValidTaxClassConfig(int $key, array $value): bool
+    {
+        if (empty($value) ||
+            empty($value['name']) ||
+            !isset($value['calc']) ||
+            !is_numeric($value['calc'])
+        ) {
+            $this->logger->error('Can\'t create tax class object for the configuration with the index=' . $key . '.', []);
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Classes/Domain/Model/Cart/TaxClassFactoryInterface.php
+++ b/Classes/Domain/Model/Cart/TaxClassFactoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Extcode\Cart\Domain\Model\Cart;
+
+/*
+ * This file is part of the package extcode/cart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+interface TaxClassFactoryInterface
+{
+    public function getTaxClass(int $taxClassKey, array $taxClassValue): ?TaxClass;
+}

--- a/Classes/Domain/Model/Cart/TaxClassInterface.php
+++ b/Classes/Domain/Model/Cart/TaxClassInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Extcode\Cart\Domain\Model\Cart;
+
+/*
+ * This file is part of the package extcode/cart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+interface TaxClassInterface
+{
+    public function getId(): int;
+
+    public function getValue(): string;
+
+    public function getCalc(): float;
+
+    public function getTitle(): string;
+}

--- a/Classes/Service/TaxClassService.php
+++ b/Classes/Service/TaxClassService.php
@@ -14,22 +14,23 @@ namespace Extcode\Cart\Service;
 use Extcode\Cart\Domain\Model\Cart\TaxClass;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
 class TaxClassService implements TaxClassServiceInterface
 {
     protected array $settings;
 
-    public function __construct(protected ConfigurationManager $configurationManager)
-    {
+    public function __construct(
+        protected ConfigurationManagerInterface $configurationManager
+    ) {
         $this->settings = $this->configurationManager->getConfiguration(
-            ConfigurationManager::CONFIGURATION_TYPE_FRAMEWORK,
+            ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
             'Cart'
         );
     }
 
     /**
-     * @inheritDoc
+     * @return TaxClass[]
      */
     public function getTaxClasses(string $countryCode = null): array
     {

--- a/Classes/Service/TaxClassServiceInterface.php
+++ b/Classes/Service/TaxClassServiceInterface.php
@@ -16,7 +16,7 @@ use Extcode\Cart\Domain\Model\Cart\TaxClass;
 interface TaxClassServiceInterface
 {
     /**
-     * @return array<TaxClass>
+     * @return TaxClass[]
      */
     public function getTaxClasses(string $countryCode = null): array;
 }

--- a/Classes/Utility/CartUtility.php
+++ b/Classes/Utility/CartUtility.php
@@ -13,27 +13,19 @@ use Extcode\Cart\Domain\Model\Cart\Cart;
 use Extcode\Cart\Domain\Model\Cart\Service;
 use Extcode\Cart\Event\Cart\UpdateCountryEvent;
 use Extcode\Cart\Service\SessionHandler;
+use Extcode\Cart\Service\TaxClassServiceInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Request;
 
 class CartUtility
 {
-    protected EventDispatcherInterface $eventDispatcher;
-
-    protected SessionHandler $sessionHandler;
-
-    protected ParserUtility $parserUtility;
-
     public function __construct(
-        EventDispatcherInterface $eventDispatcher,
-        ParserUtility $parserUtility,
-        SessionHandler $sessionHandler
-    ) {
-        $this->eventDispatcher = $eventDispatcher;
-        $this->parserUtility = $parserUtility;
-        $this->sessionHandler = $sessionHandler;
-    }
+        protected EventDispatcherInterface $eventDispatcher,
+        protected ParserUtility $parserUtility,
+        protected TaxClassServiceInterface $taxClassService,
+        protected SessionHandler $sessionHandler
+    ) {}
 
     public function getServiceById(array $services, int $serviceId): mixed
     {
@@ -104,7 +96,7 @@ class CartUtility
 
         $defaultCountry  = $configurations['settings']['countries']['options'][$configurations['settings']['countries']['preset']]['code'];
 
-        $taxClasses = $this->parserUtility->parseTaxClasses($configurations, $defaultCountry);
+        $taxClasses = $this->taxClassService->getTaxClasses($defaultCountry);
 
         /** @var Cart $cart */
         $cart = GeneralUtility::makeInstance(

--- a/Classes/Utility/ParserUtility.php
+++ b/Classes/Utility/ParserUtility.php
@@ -12,26 +12,10 @@ namespace Extcode\Cart\Utility;
 use Extcode\Cart\Domain\Model\Cart\Cart;
 use Extcode\Cart\Domain\Model\Cart\Service;
 use Extcode\Cart\Domain\Model\Cart\ServiceInterface;
-use Extcode\Cart\Service\TaxClassService;
-use Extcode\Cart\Service\TaxClassServiceInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ParserUtility
 {
-    public function parseTaxClasses(array $pluginSettings, string $countryCode = null): array
-    {
-        $className = $pluginSettings['taxClasses']['className'] ?? TaxClassService::class;
-
-        $service = GeneralUtility::makeInstance(
-            $className
-        );
-        if (!$service instanceof TaxClassServiceInterface) {
-            throw new \UnexpectedValueException($className . ' must implement interface ' . TaxClassServiceInterface::class, 123);
-        }
-
-        return $service->getTaxClasses($countryCode);
-    }
-
     /**
      * Parse Services
      *

--- a/Documentation/Changelog/9.0/Breaking-505-ReplaceParserUtilityParseTaxByDI.rst
+++ b/Documentation/Changelog/9.0/Breaking-505-ReplaceParserUtilityParseTaxByDI.rst
@@ -1,0 +1,31 @@
+.. include:: ../../Includes.txt
+
+======================================================
+Breaking: #505 - Replace ParserUtility::parseTax by DI
+======================================================
+
+See :issue:`480`
+
+Description
+===========
+
+The existing `\Extcode\Cart\Utility\ParserUtility::parseTax()` uses a TaxClassService
+which could be configured by a TypoScript Configuration. The change remove the
+method from the class and injecting the `Extcode\Cart\Service\TaxClassServiceInterface`
+by Dependency Injection.
+
+Affected Installations
+======================
+
+All installations where `plugin.tx_cart.taxClasses.className` is used to replace
+the default TaxClassService.
+
+Migration
+=========
+
+Remove the old configuration from TypoScript.
+Add an entry to your `Services.yaml` or `Services.php` and configure your
+implementation of the `Extcode\Cart\Service\TaxClassServiceInterface` for the
+`$taxClassService` constructor argument.
+
+.. index:: Backend, Dependency Injection

--- a/Tests/Functional/Service/TaxClassServiceTest.php
+++ b/Tests/Functional/Service/TaxClassServiceTest.php
@@ -16,20 +16,12 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class TaxClassServiceTest extends FunctionalTestCase
 {
-    /**
-     * @var TaxClassService
-     */
-    protected $taxClassService;
-
-    /**
-     * @var non-empty-string[]
-     */
-    protected array $testExtensionsToLoad = [
-        'typo3conf/ext/cart',
-    ];
+    protected TaxClassService $taxClassService;
 
     public function setUp(): void
     {
+        $this->testExtensionsToLoad[] = 'extcode/cart';
+
         parent::setUp();
 
         $this->taxClassService = GeneralUtility::makeInstance(

--- a/Tests/Functional/Utility/ParserUtilityTest.php
+++ b/Tests/Functional/Utility/ParserUtilityTest.php
@@ -50,50 +50,51 @@ class ParserUtilityTest extends FunctionalTestCase
 
         $pluginSettings = [
             $type => [
-                'default' => 'de',
-                'de' => [
-                    'preset' => 1,
-                    'options' => [
-                        '1' => [
-                            'title' => 'Payment 1 DE',
-                            'extra' => '0.00',
-                            'taxClassId' => '1',
-                            'status' => 'open',
-                        ],
-                        '2' => [
-                            'title' => 'Payment 2 DE',
-                            'extra' => '0.00',
-                            'taxClassId' => '1',
-                            'status' => 'open',
-                        ],
-                        '3' => [
-                            'title' => 'Payment 3 DE',
-                            'extra' => '0.00',
-                            'taxClassId' => '1',
-                            'status' => 'open',
+                'countries' => [
+                    'de' => [
+                        'preset' => 1,
+                        'options' => [
+                            '1' => [
+                                'title' => 'Payment 1 DE',
+                                'extra' => '0.00',
+                                'taxClassId' => '1',
+                                'status' => 'open',
+                            ],
+                            '2' => [
+                                'title' => 'Payment 2 DE',
+                                'extra' => '0.00',
+                                'taxClassId' => '1',
+                                'status' => 'open',
+                            ],
+                            '3' => [
+                                'title' => 'Payment 3 DE',
+                                'extra' => '0.00',
+                                'taxClassId' => '1',
+                                'status' => 'open',
+                            ],
                         ],
                     ],
-                ],
-                'at' => [
-                    'preset' => 1,
-                    'options' => [
-                        '1' => [
-                            'title' => 'Payment 1 AT',
-                            'extra' => '0.00',
-                            'taxClassId' => '1',
-                            'status' => 'open',
-                        ],
-                        '2' => [
-                            'title' => 'Payment 2 AT',
-                            'extra' => '0.00',
-                            'taxClassId' => '1',
-                            'status' => 'open',
-                        ],
-                        '3' => [
-                            'title' => 'Payment 3 AT',
-                            'extra' => '0.00',
-                            'taxClassId' => '1',
-                            'status' => 'open',
+                    'at' => [
+                        'preset' => 1,
+                        'options' => [
+                            '1' => [
+                                'title' => 'Payment 1 AT',
+                                'extra' => '0.00',
+                                'taxClassId' => '1',
+                                'status' => 'open',
+                            ],
+                            '2' => [
+                                'title' => 'Payment 2 AT',
+                                'extra' => '0.00',
+                                'taxClassId' => '1',
+                                'status' => 'open',
+                            ],
+                            '3' => [
+                                'title' => 'Payment 3 AT',
+                                'extra' => '0.00',
+                                'taxClassId' => '1',
+                                'status' => 'open',
+                            ],
                         ],
                     ],
                 ],
@@ -121,7 +122,7 @@ class ParserUtilityTest extends FunctionalTestCase
         );
 
         self::assertEquals(
-            $pluginSettings[$type][$country]['options'],
+            $pluginSettings[$type]['countries'][$country]['options'],
             $parsedData['options']
         );
     }

--- a/Tests/Functional/Utility/ParserUtilityTest.php
+++ b/Tests/Functional/Utility/ParserUtilityTest.php
@@ -17,20 +17,12 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class ParserUtilityTest extends FunctionalTestCase
 {
-    /**
-     * @var ParserUtility
-     */
-    protected $parserUtility;
-
-    /**
-     * @var non-empty-string[]
-     */
-    protected array $testExtensionsToLoad = [
-        'typo3conf/ext/cart',
-    ];
+    protected ParserUtility $parserUtility;
 
     public function setUp(): void
     {
+        $this->testExtensionsToLoad[] = 'extcode/cart';
+
         parent::setUp();
 
         $this->parserUtility = GeneralUtility::makeInstance(


### PR DESCRIPTION
Adaption of `TaxClassService` to allow DI of own `TaxClassService`. This is also a preparation for TYPO3 v13 to allow the configuration of tax classes via SiteConfiguration / SiteSets instead of getting it from TypoScript.

Implementation for PaymentMethods and ShippingMethods will follow, see #508.