### PR TITLE
[BUGFIX] Proper storage of taxes for an order

### DIFF
--- a/Classes/EventListener/Order/Create/PersistOrder/Products.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Products.php
@@ -16,7 +16,6 @@ use Extcode\Cart\Domain\Model\Cart\FeVariant;
 use Extcode\Cart\Domain\Model\Cart\Product;
 use Extcode\Cart\Domain\Model\Order\Item;
 use Extcode\Cart\Domain\Model\Order\ProductAdditional;
-use Extcode\Cart\Domain\Model\Order\Tax;
 use Extcode\Cart\Domain\Repository\Order\ProductAdditionalRepository;
 use Extcode\Cart\Domain\Repository\Order\ProductRepository;
 use Extcode\Cart\Domain\Repository\Order\TaxRepository;
@@ -185,15 +184,6 @@ class Products
      */
     protected function addBeVariant(BeVariant $variant, int $level): void
     {
-        $orderTax = GeneralUtility::makeInstance(
-            Tax::class,
-            $variant->getTax(),
-            $this->taxClasses[$variant->getTaxClass()->getId()]
-        );
-        $orderTax->setPid($this->storagePid);
-
-        $this->taxRepository->add($orderTax);
-
         $variantInner = $variant;
         for ($count = $level; $count > 0; $count--) {
             if ($count > 1) {

--- a/Classes/EventListener/Order/Create/PersistOrder/Taxes.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Taxes.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Extcode\Cart\EventListener\Order\Create\PersistOrder;
+
+/*
+ * This file is part of the package extcode/cart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Extcode\Cart\Domain\Model\Order\Item as OrderItem;
+use Extcode\Cart\Domain\Model\Order\Tax as OrderTax;
+use Extcode\Cart\Domain\Repository\Order\ItemRepository;
+use Extcode\Cart\Domain\Repository\Order\TaxRepository;
+use Extcode\Cart\Event\Order\PersistOrderEventInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+
+class Taxes
+{
+    public function __construct(
+        private PersistenceManager $persistenceManager,
+        private ItemRepository $itemRepository,
+        private TaxRepository $taxRepository
+    ) {}
+
+    public function __invoke(PersistOrderEventInterface $event): void
+    {
+        $orderItem = $event->getOrderItem();
+
+        $orderItem = $this->addTaxToRepositoryAndItem($event, $orderItem, 'tax');
+        $orderItem = $this->addTaxToRepositoryAndItem($event, $orderItem, 'totalTax');
+
+        $this->itemRepository->update($orderItem);
+        $this->persistenceManager->persistAll();
+    }
+
+    protected function addTaxToRepositoryAndItem(
+        PersistOrderEventInterface $event,
+        OrderItem $orderItem,
+        string $typeOfTax
+    ): OrderItem {
+        $cart = $event->getCart();
+        $storagePid = $event->getStoragePid();
+        $taxClasses = $event->getTaxClasses();
+
+        $taxes = $typeOfTax === 'tax' ? $cart->getTaxes() : $cart->getTotalTaxes();
+
+        /** @var int $taxClassId */
+        /** @var float $tax */
+        foreach ($taxes as $taxClassId => $tax) {
+            $taxValue = $tax;
+            $taxClass = $taxClasses[$taxClassId];
+            $orderTax = GeneralUtility::makeInstance(OrderTax::class, $taxValue, $taxClass);
+            $orderTax->setPid($storagePid);
+
+            $this->taxRepository->add($orderTax);
+
+            if ($typeOfTax === 'tax') {
+                $orderItem->addTax($orderTax);
+            } else {
+                $orderItem->addTotalTax($orderTax);
+            }
+        }
+
+        return $orderItem;
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -49,6 +49,13 @@ services:
         event: Extcode\Cart\Event\Order\PersistOrderEvent
         after: 'cart--order--create--persist-order--item'
 
+  Extcode\Cart\EventListener\Order\Create\PersistOrder\Taxes:
+    tags:
+      - name: event.listener
+        identifier: 'cart--order--create--persist-order--tax'
+        event: Extcode\Cart\Event\Order\PersistOrderEvent
+        after: 'cart--order--create--persist-order--tax-classes'
+
   Extcode\Cart\EventListener\Order\Create\PersistOrder\Products:
     tags:
       - name: event.listener

--- a/Configuration/TCA/tx_cart_domain_model_order_item.php
+++ b/Configuration/TCA/tx_cart_domain_model_order_item.php
@@ -55,11 +55,11 @@ return [
             'canNotCollapse' => 1,
         ],
         'price' => [
-            'showitem' => 'currency, --linebreak--, currency_code, currency_sign, currency_translation, --linebreak--, gross, net, --linebreak--, order_tax',
+            'showitem' => 'currency, --linebreak--, currency_code, currency_sign, currency_translation, --linebreak--, gross, net, --linebreak--, tax',
             'canNotCollapse' => 1,
         ],
         'total_price' => [
-            'showitem' => 'total_gross, total_net, --linebreak--, order_total_tax',
+            'showitem' => 'total_gross, total_net, --linebreak--, total_tax',
             'canNotCollapse' => 1,
         ],
         'pdfs' => [

--- a/Configuration/TCA/tx_cart_domain_model_order_item.php
+++ b/Configuration/TCA/tx_cart_domain_model_order_item.php
@@ -407,6 +407,9 @@ return [
                 'readOnly' => 1,
                 'foreign_table' => 'tx_cart_domain_model_order_tax',
                 'foreign_field' => 'item',
+                'foreign_match_fields' => [
+                    'type' => 'default',
+                ],
                 'maxitems' => 9999,
                 'default' => 0,
             ],
@@ -419,6 +422,9 @@ return [
                 'readOnly' => 1,
                 'foreign_table' => 'tx_cart_domain_model_order_tax',
                 'foreign_field' => 'item',
+                'foreign_match_fields' => [
+                    'type' => 'total',
+                ],
                 'maxitems' => 9999,
                 'default' => 0,
             ],

--- a/Configuration/TCA/tx_cart_domain_model_order_item.php
+++ b/Configuration/TCA/tx_cart_domain_model_order_item.php
@@ -48,23 +48,18 @@ return [
         ],
         'addresses' => [
             'showitem' => 'billing_address, shipping_address',
-            'canNotCollapse' => 0,
         ],
         'numbers' => [
             'showitem' => 'order_number, order_date, --linebreak--, invoice_number, invoice_date, --linebreak--, delivery_number, delivery_date',
-            'canNotCollapse' => 1,
         ],
         'price' => [
             'showitem' => 'currency, --linebreak--, currency_code, currency_sign, currency_translation, --linebreak--, gross, net, --linebreak--, tax',
-            'canNotCollapse' => 1,
         ],
         'total_price' => [
             'showitem' => 'total_gross, total_net, --linebreak--, total_tax',
-            'canNotCollapse' => 1,
         ],
         'pdfs' => [
             'showitem' => 'order_pdfs, --linebreak--, invoice_pdfs, --linebreak--, delivery_pdfs',
-            'canNotCollapse' => 1,
         ],
     ],
     'columns' => [

--- a/Configuration/TCA/tx_cart_domain_model_order_payment.php
+++ b/Configuration/TCA/tx_cart_domain_model_order_payment.php
@@ -30,12 +30,10 @@ return [
             'showitem' => '',
             'service' => [
                 'showitem' => 'service_country, service_id',
-                'canNotCollapse' => 0,
             ],
         ],
         'service' => [
             'showitem' => 'service_country, service_id',
-            'canNotCollapse' => 0,
         ],
     ],
     'columns' => [

--- a/Configuration/TCA/tx_cart_domain_model_order_product.php
+++ b/Configuration/TCA/tx_cart_domain_model_order_product.php
@@ -33,11 +33,9 @@ return [
         ],
         'price' => [
             'showitem' => 'price, discount, --linebreak--, gross, net, --linebreak--, tax, tax_class',
-            'canNotCollapse' => 1,
         ],
         'product_type_and_id' => [
             'showitem' => 'product_type, product_id',
-            'canNotCollapse' => 1,
         ],
     ],
     'columns' => [

--- a/Configuration/TCA/tx_cart_domain_model_order_shipping.php
+++ b/Configuration/TCA/tx_cart_domain_model_order_shipping.php
@@ -30,12 +30,10 @@ return [
             'showitem' => '',
             'service' => [
                 'showitem' => 'service_country, service_id',
-                'canNotCollapse' => 0,
             ],
         ],
         'service' => [
             'showitem' => 'service_country, service_id',
-            'canNotCollapse' => 0,
         ],
     ],
     'columns' => [

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -105,6 +105,7 @@ CREATE TABLE tx_cart_domain_model_order_tax (
     pid int(11) DEFAULT '0' NOT NULL,
 
     item int(11) unsigned DEFAULT '0' NOT NULL,
+    type varchar(255) DEFAULT '' NOT NULL,
 
     tax double(11,2) DEFAULT '0.00' NOT NULL,
     tax_class int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
* Render fields `tax` and `orderTax` in BE List module.
* Remove obsolete TCA settings `canNotCollapse`.
* Proper TCA configuration for taxes by introducing `foreign_match_fields` to correctly resolve relations.
* Add EventListener to persist taxes during an order process.
* Remove code which created unrelated tax records when ordering a product with BE variants.

Fixes: #312, #509 