### PR TITLE
[BUGFIX] Persist only existing shippingAdress

### DIFF
--- a/Classes/EventListener/Order/Create/PersistOrder/Item.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Item.php
@@ -73,6 +73,13 @@ class Item
         $orderItem->setTotalGross($cart->getTotalGross());
         $orderItem->setTotalNet($cart->getTotalNet());
 
+        /* In multistep checkout the setting `shippingSameAsBilling` might get lost for the orderItem,
+           but it does not get lost for the cart as the cart is stored between every step in the session */
+        $orderItem->setShippingSameAsBilling($cart->isShippingSameAsBilling());
+        if ($orderItem->isShippingSameAsBilling()) {
+            $orderItem->removeShippingAddress();
+        }
+
         $this->itemRepository->add($orderItem);
 
         if ($orderItem->getBillingAddress()) {


### PR DESCRIPTION
In multistep checkout the property
`shippingSameAsBilling` might get between the
steps as it does not get persisted by the
`SessionHandler`. As a result the value can become 
false although it was set to true by the customer. 
This results in orders where an empty shipping
address is persisted.

The value is also stored in the cart object which
is persisted by the `SessionHandler`. This means
we can trust this value instead.

Before persisting the `orderItem` we now transfer
the value from the `cart` and delete the
shippingAddress object if the value
`shippingSameAsBilling` is true.

Fixes: #492