### PR TITLE
[BUGFIX] `isNetCart` setting considered in cart checkout

### DIFF
--- a/Classes/Utility/CartUtility.php
+++ b/Classes/Utility/CartUtility.php
@@ -88,7 +88,8 @@ class CartUtility
      */
     public function getNewCart(array $configurations): Cart
     {
-        $isNetCart = !((int)($configurations['settings']['cart']['isNetCart']) === 0);
+        $isNetCartTypoScriptInput = $configurations['settings']['cart']['isNetCart'];
+        $isNetCart = ($isNetCartTypoScriptInput === '1' || $isNetCartTypoScriptInput === 'true');
 
         $preset = $configurations['settings']['currencies']['preset'];
         if ($configurations['settings']['currencies']['options'][$preset]) {

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -74,6 +74,9 @@
             <trans-unit id="tx_cart_domain_model_cart_product.price_per_unit_net">
                 <source>Price per unit (net)</source>
             </trans-unit>
+            <trans-unit id="tx_cart_domain_model_cart_product.price_per_unit_gross">
+                <source>Price per unit (gross)</source>
+            </trans-unit>
             <trans-unit id="tx_cart_domain_model_cart_product.price_subtotal">
                 <source>Subtotal</source>
             </trans-unit>

--- a/Resources/Private/Partials/Cart/Confirmation/ProductList.html
+++ b/Resources/Private/Partials/Cart/Confirmation/ProductList.html
@@ -124,7 +124,14 @@
                         <f:translate key="tx_cart_domain_model_cart_product.title"/>
                     </th>
                     <th class="col-md-2 text-right">
-                        <f:translate key="tx_cart_domain_model_cart_product.price_per_unit_net"/>
+                        <f:if condition="{cart.netCart}">
+                            <f:then>
+                                <f:translate key="tx_cart_domain_model_cart_product.price_per_unit_net"/>
+                            </f:then>
+                            <f:else>
+                                <f:translate key="tx_cart_domain_model_cart_product.price_per_unit_gross"/>
+                            </f:else>
+                        </f:if>
                     </th>
                     <th class="col-md-1">
                         <f:translate key="tx_cart_domain_model_cart_product.count"/>

--- a/Resources/Private/Partials/Cart/OrderForm/PaymentMethod.html
+++ b/Resources/Private/Partials/Cart/OrderForm/PaymentMethod.html
@@ -31,7 +31,12 @@
                             </f:if>
                         </div>
                         <div class="method-item-info">
-                            <cart:format.currency currencySign="{cart.currencySign}">{payment.gross}</cart:format.currency>
+                            <cart:format.currency currencySign="{cart.currencySign}">
+                                <f:if condition="{cart.netCart}">
+                                    <f:then>{payment.net}</f:then>
+                                    <f:else>{payment.gross}</f:else>
+                                </f:if>
+                            </cart:format.currency>
                         </div>
                     </f:if>
                 </f:for>

--- a/Resources/Private/Partials/Cart/OrderForm/ShippingMethod.html
+++ b/Resources/Private/Partials/Cart/OrderForm/ShippingMethod.html
@@ -31,7 +31,12 @@
                             </f:if>
                         </div>
                         <div class="method-item-info">
-                            <cart:format.currency currencySign="{cart.currencySign}">{shipping.gross}</cart:format.currency>
+                            <cart:format.currency currencySign="{cart.currencySign}">
+                                <f:if condition="{cart.netCart}">
+                                    <f:then>{shipping.net}</f:then>
+                                    <f:else>{shipping.gross}</f:else>
+                                </f:if>
+                            </cart:format.currency>
                         </div>
                     </f:if>
                 </f:for>


### PR DESCRIPTION
Setting
`plugin.tx_cart.settings.cart.isNetCart = false`
now rules the output of some values and labels
properly

* The price of products in the last step
  of the multistep checkout are gross prices.
  With this bugfix the header of the table shows
  "Price per unit (gross)" if needed instead of
  always showing "Price per unit (net).
* The costs for shipping and payment are 
  correctly shown as gross or net values.

Fixes: https://github.com/extcode/cart/issues/515