### PR TITLE
[BUGFIX] Use PRG pattern for multistep checkout

### DIFF
--- a/Classes/Controller/Cart/CartController.php
+++ b/Classes/Controller/Cart/CartController.php
@@ -118,7 +118,22 @@ class CartController extends ActionController
             ]
         );
 
+        // Use Post/Redirect/Get pattern for multistep checkout
+
+        $currentStep = null;
+        if ($this->request->hasArgument('step')) {
+            $currentStep = (int)$this->request->getArgument('step');
+        }
+
+        if ($currentStep && $this->request->getMethod() === 'POST') {
+            return $this->redirect('show', null, null, ['step' => $currentStep])->withStatus(303);
+        }
+        // Redirect to step 1 if cart is empty.
+        if (count($this->cart->getProducts()) === 0 && $currentStep > 1) {
+            return $this->redirect('show', null, null, ['step' => 1])->withStatus(303);
+        }
         return $this->htmlResponse();
+
     }
 
     public function clearAction(): ResponseInterface


### PR DESCRIPTION
Avoid errors when navigating in the multistep
checkout between different steps with the browser
navigation (back and forward buttons of the
browser) by redirecting to the same page.

To avoid that the customer can go back to the
last step of the multistep checkout after sending
the order we also redirect to the first page of
the checkout if there are no products in the cart.

Fixes: #518