### PR TITLE
[BUGFIX] Proper storage of taxes for an order

### DIFF
--- a/Classes/EventListener/Order/Create/Order.php
+++ b/Classes/EventListener/Order/Create/Order.php
@@ -18,17 +18,10 @@ use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
 class Order
 {
-    private EventDispatcherInterface $eventDispatcher;
-
-    private PersistenceManager $persistenceManager;
-
     public function __construct(
-        EventDispatcherInterface $eventDispatcher,
-        PersistenceManager $persistenceManager
-    ) {
-        $this->eventDispatcher = $eventDispatcher;
-        $this->persistenceManager = $persistenceManager;
-    }
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly PersistenceManager $persistenceManager
+    ) {}
 
     public function __invoke(EventInterface $event): void
     {

--- a/Classes/EventListener/Order/Create/PersistOrder/Coupons.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Coupons.php
@@ -22,25 +22,12 @@ use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
 class Coupons
 {
-    private PersistenceManager $persistenceManager;
-
-    private ItemRepository $itemRepository;
-
-    private DiscountRepository $discountRepository;
-
-    private CouponRepository $couponRepository;
-
     public function __construct(
-        PersistenceManager $persistenceManager,
-        ItemRepository $itemRepository,
-        DiscountRepository $discountRepository,
-        CouponRepository $couponRepository
-    ) {
-        $this->persistenceManager = $persistenceManager;
-        $this->itemRepository = $itemRepository;
-        $this->discountRepository = $discountRepository;
-        $this->couponRepository = $couponRepository;
-    }
+        private readonly PersistenceManager $persistenceManager,
+        private readonly ItemRepository $itemRepository,
+        private readonly DiscountRepository $discountRepository,
+        private readonly CouponRepository $couponRepository
+    ) {}
 
     public function __invoke(PersistOrderEventInterface $event): void
     {

--- a/Classes/EventListener/Order/Create/PersistOrder/Item.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Item.php
@@ -22,25 +22,12 @@ use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
 class Item
 {
-    private PersistenceManager $persistenceManager;
-
-    private ItemRepository $itemRepository;
-
-    private BillingAddressRepository $billingAddressRepository;
-
-    private ShippingAddressRepository $shippingAddressRepository;
-
     public function __construct(
-        PersistenceManager $persistenceManager,
-        ItemRepository $itemRepository,
-        BillingAddressRepository $billingAddressRepository,
-        ShippingAddressRepository $shippingAddressRepository
-    ) {
-        $this->persistenceManager = $persistenceManager;
-        $this->itemRepository = $itemRepository;
-        $this->billingAddressRepository = $billingAddressRepository;
-        $this->shippingAddressRepository = $shippingAddressRepository;
-    }
+        private readonly PersistenceManager $persistenceManager,
+        private readonly ItemRepository $itemRepository,
+        private readonly BillingAddressRepository $billingAddressRepository,
+        private readonly ShippingAddressRepository $shippingAddressRepository
+    ) {}
 
     public function __invoke(PersistOrderEventInterface $event): void
     {

--- a/Classes/EventListener/Order/Create/PersistOrder/Payment.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Payment.php
@@ -19,21 +19,11 @@ use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
 class Payment
 {
-    private PersistenceManager $persistenceManager;
-
-    private ItemRepository $itemRepository;
-
-    private PaymentRepository $paymentRepository;
-
     public function __construct(
-        PersistenceManager $persistenceManager,
-        ItemRepository $itemRepository,
-        PaymentRepository $paymentRepository
-    ) {
-        $this->persistenceManager = $persistenceManager;
-        $this->itemRepository = $itemRepository;
-        $this->paymentRepository = $paymentRepository;
-    }
+        private readonly PersistenceManager $persistenceManager,
+        private readonly ItemRepository $itemRepository,
+        private readonly PaymentRepository $paymentRepository
+    ) {}
 
     public function __invoke(PersistOrderEventInterface $event): void
     {

--- a/Classes/EventListener/Order/Create/PersistOrder/Products.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Products.php
@@ -16,7 +16,6 @@ use Extcode\Cart\Domain\Model\Cart\FeVariant;
 use Extcode\Cart\Domain\Model\Cart\Product;
 use Extcode\Cart\Domain\Model\Order\Item;
 use Extcode\Cart\Domain\Model\Order\ProductAdditional;
-use Extcode\Cart\Domain\Model\Order\Tax;
 use Extcode\Cart\Domain\Repository\Order\ProductAdditionalRepository;
 use Extcode\Cart\Domain\Repository\Order\ProductRepository;
 use Extcode\Cart\Domain\Repository\Order\TaxRepository;
@@ -185,15 +184,6 @@ class Products
      */
     protected function addBeVariant(BeVariant $variant, int $level): void
     {
-        $orderTax = GeneralUtility::makeInstance(
-            Tax::class,
-            $variant->getTax(),
-            $this->taxClasses[$variant->getTaxClass()->getId()]
-        );
-        $orderTax->setPid($this->storagePid);
-
-        $this->taxRepository->add($orderTax);
-
         $variantInner = $variant;
         for ($count = $level; $count > 0; $count--) {
             if ($count > 1) {

--- a/Classes/EventListener/Order/Create/PersistOrder/Products.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Products.php
@@ -18,21 +18,12 @@ use Extcode\Cart\Domain\Model\Order\Item;
 use Extcode\Cart\Domain\Model\Order\ProductAdditional;
 use Extcode\Cart\Domain\Repository\Order\ProductAdditionalRepository;
 use Extcode\Cart\Domain\Repository\Order\ProductRepository;
-use Extcode\Cart\Domain\Repository\Order\TaxRepository;
 use Extcode\Cart\Event\Order\PersistOrderEventInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
 class Products
 {
-    private PersistenceManager $persistenceManager;
-
-    private ProductRepository $productRepository;
-
-    private ProductAdditionalRepository $productAdditionalRepository;
-
-    private TaxRepository $taxRepository;
-
     private Item $orderItem;
 
     protected array $taxClasses;
@@ -40,20 +31,13 @@ class Products
     private int $storagePid;
 
     public function __construct(
-        PersistenceManager $persistenceManager,
-        ProductRepository $productRepository,
-        ProductAdditionalRepository $productAdditionalRepository,
-        TaxRepository $taxRepository
-    ) {
-        $this->persistenceManager = $persistenceManager;
-        $this->productRepository = $productRepository;
-        $this->productAdditionalRepository = $productAdditionalRepository;
-        $this->taxRepository = $taxRepository;
-    }
+        private readonly PersistenceManager $persistenceManager,
+        private readonly ProductRepository $productRepository,
+        private readonly ProductAdditionalRepository $productAdditionalRepository
+    ) {}
 
     public function __invoke(PersistOrderEventInterface $event): void
     {
-        $settings = $event->getSettings();
         $cart = $event->getCart();
         $this->orderItem = $event->getOrderItem();
         $this->storagePid = $event->getStoragePid();
@@ -70,12 +54,7 @@ class Products
         $this->persistenceManager->persistAll();
     }
 
-    /**
-     * Add CartProduct to Order Item
-     *
-     * @param Product $cartProduct
-     */
-    protected function addProduct(Product $cartProduct)
+    protected function addProduct(Product $cartProduct): void
     {
         $orderProduct = GeneralUtility::makeInstance(
             \Extcode\Cart\Domain\Model\Order\Product::class
@@ -103,12 +82,7 @@ class Products
         $this->addFeVariants($orderProduct, $cartProduct->getFeVariant());
     }
 
-    /**
-     * Adds Variants of a CartProduct to Order Item
-     *
-     * @param Product $product CartProduct
-     */
-    protected function addProductVariants(Product $product)
+    protected function addProductVariants(Product $product): void
     {
         foreach ($product->getBeVariants() as $variant) {
             /**
@@ -126,7 +100,7 @@ class Products
     protected function addFeVariants(
         \Extcode\Cart\Domain\Model\Order\Product $product,
         FeVariant $feVariant = null
-    ) {
+    ): void {
         if ($feVariant) {
             $feVariantsData = $feVariant->getVariantData();
             if ($feVariantsData) {
@@ -159,9 +133,6 @@ class Products
         $product->addProductAdditional($productAdditional);
     }
 
-    /**
-     * Adds Variants of a Variant to Order Item
-     */
     protected function addVariantsOfVariant(BeVariant $variant, int $level): void
     {
         $level += 1;
@@ -179,9 +150,6 @@ class Products
         }
     }
 
-    /**
-     * Adds a Variant to Order Item
-     */
     protected function addBeVariant(BeVariant $variant, int $level): void
     {
         $variantInner = $variant;

--- a/Classes/EventListener/Order/Create/PersistOrder/Shipping.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Shipping.php
@@ -19,21 +19,11 @@ use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
 class Shipping
 {
-    private PersistenceManager $persistenceManager;
-
-    private ItemRepository $itemRepository;
-
-    private ShippingRepository $shippingRepository;
-
     public function __construct(
-        PersistenceManager $persistenceManager,
-        ItemRepository $itemRepository,
-        ShippingRepository $shippingRepository
-    ) {
-        $this->persistenceManager = $persistenceManager;
-        $this->itemRepository = $itemRepository;
-        $this->shippingRepository = $shippingRepository;
-    }
+        private readonly PersistenceManager $persistenceManager,
+        private readonly ItemRepository $itemRepository,
+        private readonly ShippingRepository $shippingRepository
+    ) {}
 
     public function __invoke(PersistOrderEventInterface $event): void
     {

--- a/Classes/EventListener/Order/Create/PersistOrder/TaxClasses.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/TaxClasses.php
@@ -20,21 +20,11 @@ use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
 class TaxClasses
 {
-    private PersistenceManager $persistenceManager;
-
-    private ItemRepository $itemRepository;
-
-    private TaxClassRepository $taxClassRepository;
-
     public function __construct(
-        PersistenceManager $persistenceManager,
-        ItemRepository $itemRepository,
-        TaxClassRepository $taxClassRepository
-    ) {
-        $this->persistenceManager = $persistenceManager;
-        $this->itemRepository = $itemRepository;
-        $this->taxClassRepository = $taxClassRepository;
-    }
+        private readonly PersistenceManager $persistenceManager,
+        private readonly ItemRepository $itemRepository,
+        private readonly TaxClassRepository $taxClassRepository
+    ) {}
 
     public function __invoke(PersistOrderEventInterface $event): void
     {

--- a/Classes/EventListener/Order/Create/PersistOrder/Taxes.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Taxes.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Extcode\Cart\EventListener\Order\Create\PersistOrder;
+
+/*
+ * This file is part of the package extcode/cart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Extcode\Cart\Domain\Model\Order\Item as OrderItem;
+use Extcode\Cart\Domain\Model\Order\Tax as OrderTax;
+use Extcode\Cart\Domain\Repository\Order\ItemRepository;
+use Extcode\Cart\Domain\Repository\Order\TaxRepository;
+use Extcode\Cart\Event\Order\PersistOrderEventInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+
+class Taxes
+{
+    public function __construct(
+        private PersistenceManager $persistenceManager,
+        private ItemRepository $itemRepository,
+        private TaxRepository $taxRepository
+    ) {}
+
+    public function __invoke(PersistOrderEventInterface $event): void
+    {
+        $orderItem = $event->getOrderItem();
+
+        $orderItem = $this->addTaxToRepositoryAndItem($event, $orderItem, 'tax');
+        $orderItem = $this->addTaxToRepositoryAndItem($event, $orderItem, 'totalTax');
+
+        $this->itemRepository->update($orderItem);
+        $this->persistenceManager->persistAll();
+    }
+
+    protected function addTaxToRepositoryAndItem(
+        PersistOrderEventInterface $event,
+        OrderItem $orderItem,
+        string $typeOfTax
+    ): OrderItem {
+        $cart = $event->getCart();
+        $storagePid = $event->getStoragePid();
+        $taxClasses = $event->getTaxClasses();
+
+        $taxes = $typeOfTax === 'tax' ? $cart->getTaxes() : $cart->getTotalTaxes();
+
+        /** @var int $taxClassId */
+        /** @var float $tax */
+        foreach ($taxes as $taxClassId => $tax) {
+            $taxValue = $tax;
+            $taxClass = $taxClasses[$taxClassId];
+            $orderTax = GeneralUtility::makeInstance(OrderTax::class, $taxValue, $taxClass);
+            $orderTax->setPid($storagePid);
+
+            $this->taxRepository->add($orderTax);
+
+            if ($typeOfTax === 'tax') {
+                $orderItem->addTax($orderTax);
+            } else {
+                $orderItem->addTotalTax($orderTax);
+            }
+        }
+
+        return $orderItem;
+    }
+}

--- a/Classes/EventListener/Order/Create/PersistOrder/Taxes.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Taxes.php
@@ -49,12 +49,12 @@ class Taxes
 
         $taxes = $typeOfTax === 'tax' ? $cart->getTaxes() : $cart->getTotalTaxes();
 
-        /** @var int $taxClassId */
-        /** @var float $tax */
-        foreach ($taxes as $taxClassId => $tax) {
-            $taxValue = $tax;
-            $taxClass = $taxClasses[$taxClassId];
-            $orderTax = GeneralUtility::makeInstance(OrderTax::class, $taxValue, $taxClass);
+        foreach ($taxes as $taxClassId => $taxValue) {
+            $orderTax = GeneralUtility::makeInstance(
+                OrderTax::class,
+                $taxValue,
+                $taxClasses[$taxClassId]
+            );
             $orderTax->setPid($storagePid);
 
             $this->taxRepository->add($orderTax);

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -49,6 +49,13 @@ services:
         event: Extcode\Cart\Event\Order\PersistOrderEvent
         after: 'cart--order--create--persist-order--item'
 
+  Extcode\Cart\EventListener\Order\Create\PersistOrder\Taxes:
+    tags:
+      - name: event.listener
+        identifier: 'cart--order--create--persist-order--tax'
+        event: Extcode\Cart\Event\Order\PersistOrderEvent
+        after: 'cart--order--create--persist-order--tax-classes'
+
   Extcode\Cart\EventListener\Order\Create\PersistOrder\Products:
     tags:
       - name: event.listener

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -52,7 +52,7 @@ services:
   Extcode\Cart\EventListener\Order\Create\PersistOrder\Taxes:
     tags:
       - name: event.listener
-        identifier: 'cart--order--create--persist-order--tax'
+        identifier: 'cart--order--create--persist-order--taxes'
         event: Extcode\Cart\Event\Order\PersistOrderEvent
         after: 'cart--order--create--persist-order--tax-classes'
 

--- a/Configuration/TCA/tx_cart_domain_model_order_item.php
+++ b/Configuration/TCA/tx_cart_domain_model_order_item.php
@@ -48,23 +48,18 @@ return [
         ],
         'addresses' => [
             'showitem' => 'billing_address, shipping_address',
-            'canNotCollapse' => 0,
         ],
         'numbers' => [
             'showitem' => 'order_number, order_date, --linebreak--, invoice_number, invoice_date, --linebreak--, delivery_number, delivery_date',
-            'canNotCollapse' => 1,
         ],
         'price' => [
-            'showitem' => 'currency, --linebreak--, currency_code, currency_sign, currency_translation, --linebreak--, gross, net, --linebreak--, order_tax',
-            'canNotCollapse' => 1,
+            'showitem' => 'currency, --linebreak--, currency_code, currency_sign, currency_translation, --linebreak--, gross, net, --linebreak--, tax',
         ],
         'total_price' => [
-            'showitem' => 'total_gross, total_net, --linebreak--, order_total_tax',
-            'canNotCollapse' => 1,
+            'showitem' => 'total_gross, total_net, --linebreak--, total_tax',
         ],
         'pdfs' => [
             'showitem' => 'order_pdfs, --linebreak--, invoice_pdfs, --linebreak--, delivery_pdfs',
-            'canNotCollapse' => 1,
         ],
     ],
     'columns' => [

--- a/Configuration/TCA/tx_cart_domain_model_order_item.php
+++ b/Configuration/TCA/tx_cart_domain_model_order_item.php
@@ -412,6 +412,9 @@ return [
                 'readOnly' => 1,
                 'foreign_table' => 'tx_cart_domain_model_order_tax',
                 'foreign_field' => 'item',
+                'foreign_match_fields' => [
+                    'record_type' => 'tax',
+                ],
                 'maxitems' => 9999,
                 'default' => 0,
             ],
@@ -424,6 +427,9 @@ return [
                 'readOnly' => 1,
                 'foreign_table' => 'tx_cart_domain_model_order_tax',
                 'foreign_field' => 'item',
+                'foreign_match_fields' => [
+                    'record_type' => 'total_tax',
+                ],
                 'maxitems' => 9999,
                 'default' => 0,
             ],

--- a/Configuration/TCA/tx_cart_domain_model_order_payment.php
+++ b/Configuration/TCA/tx_cart_domain_model_order_payment.php
@@ -30,12 +30,10 @@ return [
             'showitem' => '',
             'service' => [
                 'showitem' => 'service_country, service_id',
-                'canNotCollapse' => 0,
             ],
         ],
         'service' => [
             'showitem' => 'service_country, service_id',
-            'canNotCollapse' => 0,
         ],
     ],
     'columns' => [

--- a/Configuration/TCA/tx_cart_domain_model_order_product.php
+++ b/Configuration/TCA/tx_cart_domain_model_order_product.php
@@ -33,11 +33,9 @@ return [
         ],
         'price' => [
             'showitem' => 'price, discount, --linebreak--, gross, net, --linebreak--, tax, tax_class',
-            'canNotCollapse' => 1,
         ],
         'product_type_and_id' => [
             'showitem' => 'product_type, product_id',
-            'canNotCollapse' => 1,
         ],
     ],
     'columns' => [

--- a/Configuration/TCA/tx_cart_domain_model_order_shipping.php
+++ b/Configuration/TCA/tx_cart_domain_model_order_shipping.php
@@ -30,12 +30,10 @@ return [
             'showitem' => '',
             'service' => [
                 'showitem' => 'service_country, service_id',
-                'canNotCollapse' => 0,
             ],
         ],
         'service' => [
             'showitem' => 'service_country, service_id',
-            'canNotCollapse' => 0,
         ],
     ],
     'columns' => [

--- a/Configuration/TCA/tx_cart_domain_model_order_tax.php
+++ b/Configuration/TCA/tx_cart_domain_model_order_tax.php
@@ -18,10 +18,14 @@ return [
         'enablecolumns' => [],
         'searchFields' => '',
         'iconfile' => 'EXT:cart/Resources/Public/Icons/Order/Tax.svg',
+        'type' => 'record_type',
     ],
     'hideTable' => 1,
     'types' => [
-        '1' => [
+        'tax' => [
+            'showitem' => 'tax, tax_class',
+        ],
+        'total_tax' => [
             'showitem' => 'tax, tax_class',
         ],
     ],

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -105,6 +105,7 @@ CREATE TABLE tx_cart_domain_model_order_tax (
     pid int(11) DEFAULT '0' NOT NULL,
 
     item int(11) unsigned DEFAULT '0' NOT NULL,
+    record_type varchar(255) DEFAULT '' NOT NULL,
 
     tax double(11,2) DEFAULT '0.00' NOT NULL,
     tax_class int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Render fields tax and orderTax in BE List module.

- Remove obsolete TCA settings canNotCollapse.
- Proper TCA configuration for taxes by introducing foreign_match_fields to correctly resolve relations.
- Add EventListener to persist taxes during an order process.
- Remove code which created unrelated tax records when ordering a product with BE variants.

Fixes: #312, #509