### PR TITLE
[TASK] Add labels for gender

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -423,6 +423,18 @@
             <trans-unit id="tx_cart_domain_model_order_address.salutation">
                 <source>Salutation</source>
             </trans-unit>
+            <trans-unit id="tx_cart_domain_model_order_address.gender.female">
+                <source>Female</source>
+            </trans-unit>
+            <trans-unit id="tx_cart_domain_model_order_address.gender.male">
+                <source>Male</source>
+            </trans-unit>
+            <trans-unit id="tx_cart_domain_model_order_address.gender.not_set">
+                <source>Not set</source>
+            </trans-unit>
+            <trans-unit id="tx_cart_domain_model_order_address.gender.various">
+                <source>Various</source>
+            </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_address.first_name">
                 <source>First Name</source>
             </trans-unit>


### PR DESCRIPTION
Provide labels for gender which makes it
easier for integrators to set up
radio buttons for the salutation instead
of using the default text input field.

With these labels in place a tutorial can
be added to the documentation how 
integrators can replace the default input
field with radio buttons. Furthermore another
step could be to add an opt-in solution to 
switch to radio button for the addresses.