### PR TITLE
[BUGFIX] Readd order item label

### DIFF
--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -75,6 +75,9 @@
                 <source>free</source>
             </trans-unit>
 
+            <trans-unit id="tx_cart_domain_model_order_item">
+                <source>Order</source>
+            </trans-unit>
             <trans-unit id="tx_cart_domain_model_order_item.palettes.numbers">
                 <source>Order and Invoice Number</source>
             </trans-unit>


### PR DESCRIPTION
The order item label was removed during the clean up although it's needed in the Backend Users module.