### PR TITLE
[BUGFIX] Use correct label in BE pagination

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -591,6 +591,9 @@
             <trans-unit id="tx_cart.backend.filter.end_date">
                 <source>End Date</source>
             </trans-unit>
+            <trans-unit id="tx_cart.backend.pagination.records">
+                <source>Records</source>
+            </trans-unit>
             <trans-unit id="tx_cart.backend.filter.no_results">
                 <source>No results for this filter</source>
             </trans-unit>

--- a/Resources/Private/Partials/Utility/Paginator.html
+++ b/Resources/Private/Partials/Utility/Paginator.html
@@ -31,7 +31,7 @@
 
         <li class="page-item">
         <span class="page-link">
-            <f:translate key="LLL:EXT:sf_event_mgt/Resources/Private/Language/locallang_be.xlf:administration.pagination.records" /> {pagination.startRecordNumber} - {pagination.endRecordNumber}
+            <f:translate key="tx_cart.backend.pagination.records" /> {pagination.startRecordNumber} - {pagination.endRecordNumber}
         </span>
         </li>
 


### PR DESCRIPTION
Replace a copy-paste error and show the correct
label instead in the counter of the pagination
of the BE.