### PR TITLE
[BUGFIX] Remove falsy path in phplint config

### DIFF
--- a/Build/phplint.yaml
+++ b/Build/phplint.yaml
@@ -1,4 +1,3 @@
-path: ./../
 jobs: 10
 cache: .phplint.cache
 extensions:


### PR DESCRIPTION
Setting the path to `path: ./../` gets wrong
results as it make the linter running in the
parent directory of the extensoin. 
Simply removing works when
running it with the composer command.

Note: phplint is not used by the CI!