### PR TITLE
[CLEANUP] ignore php warning if no page is selected via the page tree

### DIFF
--- a/Classes/Controller/Backend/ActionController.php
+++ b/Classes/Controller/Backend/ActionController.php
@@ -26,7 +26,7 @@ class ActionController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
                 ConfigurationManager::CONFIGURATION_TYPE_FRAMEWORK
             );
 
-        $pageId = (int)$this->request->getQueryParams()['id'] ?? 1;
+        $pageId = (int)@$this->request->getQueryParams()['id'] ?? 1;
 
         BackendUtility::readPageAccess(
             $pageId,


### PR DESCRIPTION
![Screenshot from 2024-08-12 12-35-45](https://github.com/user-attachments/assets/5c4accad-e530-4272-9aa8-1761b380a413)

reproduce:
- delete the pid query param / open the BE and directly go to the Cart BE Modules

Best regards.