### PR TITLE
[BUGFIX] Switch order of PaymentEvent & StockEvent

### DIFF
--- a/Classes/Controller/Cart/OrderController.php
+++ b/Classes/Controller/Cart/OrderController.php
@@ -220,15 +220,15 @@ class OrderController extends ActionController
             return true;
         }
 
-        $stockEvent = new StockEvent($this->cart, $orderItem, $this->configurations);
-        $this->eventDispatcher->dispatch($stockEvent);
-        if ($stockEvent instanceof StoppableEventInterface && $stockEvent->isPropagationStopped()) {
-            return true;
-        }
-
         $paymentEvent = new PaymentEvent($this->cart, $orderItem, $this->configurations);
         $this->eventDispatcher->dispatch($paymentEvent);
         if ($paymentEvent instanceof StoppableEventInterface && $paymentEvent->isPropagationStopped()) {
+            return true;
+        }
+
+        $stockEvent = new StockEvent($this->cart, $orderItem, $this->configurations);
+        $this->eventDispatcher->dispatch($stockEvent);
+        if ($stockEvent instanceof StoppableEventInterface && $stockEvent->isPropagationStopped()) {
             return true;
         }
 


### PR DESCRIPTION
The PaymentEvent has to be placed before the
StockEvent because the order can fail in the
PaymentEvent so the StockEvent has to be placed
after the PaymentEvent.
In case a PaymentProvider uses forwarding the
PaymentEvent and FinishEvent has to be triggered
within the EventListener of the PaymentEvent.
This is already described in the docs.

Fixes: #571