### PR TITLE
[TASK] Replace EventInterfaces by specific Events

### DIFF
--- a/Classes/EventListener/Cart/UpdateCountry.php
+++ b/Classes/EventListener/Cart/UpdateCountry.php
@@ -11,11 +11,11 @@ namespace Extcode\Cart\EventListener\Cart;
  * LICENSE file that was distributed with this source code.
  */
 
-use Extcode\Cart\Event\Cart\UpdateCountryEventInterface;
+use Extcode\Cart\Event\Cart\UpdateCountryEvent;
 
 class UpdateCountry
 {
-    public function __invoke(UpdateCountryEventInterface $event): void
+    public function __invoke(UpdateCountryEvent $event): void
     {
         $cart = $event->getCart();
         $request = $event->getRequest();

--- a/Classes/EventListener/Cart/UpdateCurrency.php
+++ b/Classes/EventListener/Cart/UpdateCurrency.php
@@ -11,11 +11,11 @@ namespace Extcode\Cart\EventListener\Cart;
  * LICENSE file that was distributed with this source code.
  */
 
-use Extcode\Cart\Event\Cart\UpdateCurrencyEventInterface;
+use Extcode\Cart\Event\Cart\UpdateCurrencyEvent;
 
 class UpdateCurrency
 {
-    public function __invoke(UpdateCurrencyEventInterface $event): void
+    public function __invoke(UpdateCurrencyEvent $event): void
     {
         $cart = $event->getCart();
         $request = $event->getRequest();

--- a/Classes/EventListener/Order/Create/Order.php
+++ b/Classes/EventListener/Order/Create/Order.php
@@ -11,7 +11,7 @@ namespace Extcode\Cart\EventListener\Order\Create;
  * LICENSE file that was distributed with this source code.
  */
 
-use Extcode\Cart\Event\Order\EventInterface;
+use Extcode\Cart\Event\Order\CreateEvent;
 use Extcode\Cart\Event\Order\PersistOrderEvent;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -23,7 +23,7 @@ class Order
         private readonly PersistenceManager $persistenceManager
     ) {}
 
-    public function __invoke(EventInterface $event): void
+    public function __invoke(CreateEvent $event): void
     {
         $settings = $event->getSettings();
         $cart = $event->getCart();

--- a/Classes/EventListener/Order/Create/PersistOrder/Coupons.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Coupons.php
@@ -16,7 +16,7 @@ use Extcode\Cart\Domain\Model\Order\Discount;
 use Extcode\Cart\Domain\Repository\CouponRepository;
 use Extcode\Cart\Domain\Repository\Order\DiscountRepository;
 use Extcode\Cart\Domain\Repository\Order\ItemRepository;
-use Extcode\Cart\Event\Order\PersistOrderEventInterface;
+use Extcode\Cart\Event\Order\PersistOrderEvent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
@@ -29,7 +29,7 @@ class Coupons
         private readonly CouponRepository $couponRepository
     ) {}
 
-    public function __invoke(PersistOrderEventInterface $event): void
+    public function __invoke(PersistOrderEvent $event): void
     {
         $cart = $event->getCart();
         $orderItem = $event->getOrderItem();

--- a/Classes/EventListener/Order/Create/PersistOrder/Item.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Item.php
@@ -15,7 +15,7 @@ use Extcode\Cart\Domain\Repository\FrontendUserRepository;
 use Extcode\Cart\Domain\Repository\Order\BillingAddressRepository;
 use Extcode\Cart\Domain\Repository\Order\ItemRepository;
 use Extcode\Cart\Domain\Repository\Order\ShippingAddressRepository;
-use Extcode\Cart\Event\Order\PersistOrderEventInterface;
+use Extcode\Cart\Event\Order\PersistOrderEvent;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -29,7 +29,7 @@ class Item
         private readonly ShippingAddressRepository $shippingAddressRepository
     ) {}
 
-    public function __invoke(PersistOrderEventInterface $event): void
+    public function __invoke(PersistOrderEvent $event): void
     {
         $settings = $event->getSettings();
         $storagePid = $event->getStoragePid();

--- a/Classes/EventListener/Order/Create/PersistOrder/Payment.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Payment.php
@@ -13,7 +13,7 @@ namespace Extcode\Cart\EventListener\Order\Create\PersistOrder;
 
 use Extcode\Cart\Domain\Repository\Order\ItemRepository;
 use Extcode\Cart\Domain\Repository\Order\PaymentRepository;
-use Extcode\Cart\Event\Order\PersistOrderEventInterface;
+use Extcode\Cart\Event\Order\PersistOrderEvent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
@@ -25,7 +25,7 @@ class Payment
         private readonly PaymentRepository $paymentRepository
     ) {}
 
-    public function __invoke(PersistOrderEventInterface $event): void
+    public function __invoke(PersistOrderEvent $event): void
     {
         $cart = $event->getCart();
         $orderItem = $event->getOrderItem();

--- a/Classes/EventListener/Order/Create/PersistOrder/Products.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Products.php
@@ -18,7 +18,7 @@ use Extcode\Cart\Domain\Model\Order\Item;
 use Extcode\Cart\Domain\Model\Order\ProductAdditional;
 use Extcode\Cart\Domain\Repository\Order\ProductAdditionalRepository;
 use Extcode\Cart\Domain\Repository\Order\ProductRepository;
-use Extcode\Cart\Event\Order\PersistOrderEventInterface;
+use Extcode\Cart\Event\Order\PersistOrderEvent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
@@ -36,7 +36,7 @@ class Products
         private readonly ProductAdditionalRepository $productAdditionalRepository
     ) {}
 
-    public function __invoke(PersistOrderEventInterface $event): void
+    public function __invoke(PersistOrderEvent $event): void
     {
         $cart = $event->getCart();
         $this->orderItem = $event->getOrderItem();

--- a/Classes/EventListener/Order/Create/PersistOrder/Shipping.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Shipping.php
@@ -13,7 +13,7 @@ namespace Extcode\Cart\EventListener\Order\Create\PersistOrder;
 
 use Extcode\Cart\Domain\Repository\Order\ItemRepository;
 use Extcode\Cart\Domain\Repository\Order\ShippingRepository;
-use Extcode\Cart\Event\Order\PersistOrderEventInterface;
+use Extcode\Cart\Event\Order\PersistOrderEvent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
@@ -25,7 +25,7 @@ class Shipping
         private readonly ShippingRepository $shippingRepository
     ) {}
 
-    public function __invoke(PersistOrderEventInterface $event): void
+    public function __invoke(PersistOrderEvent $event): void
     {
         $cart = $event->getCart();
         $orderItem = $event->getOrderItem();

--- a/Classes/EventListener/Order/Create/PersistOrder/TaxClasses.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/TaxClasses.php
@@ -14,7 +14,7 @@ namespace Extcode\Cart\EventListener\Order\Create\PersistOrder;
 use Extcode\Cart\Domain\Model\Order\TaxClass;
 use Extcode\Cart\Domain\Repository\Order\ItemRepository;
 use Extcode\Cart\Domain\Repository\Order\TaxClassRepository;
-use Extcode\Cart\Event\Order\PersistOrderEventInterface;
+use Extcode\Cart\Event\Order\PersistOrderEvent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
@@ -26,7 +26,7 @@ class TaxClasses
         private readonly TaxClassRepository $taxClassRepository
     ) {}
 
-    public function __invoke(PersistOrderEventInterface $event): void
+    public function __invoke(PersistOrderEvent $event): void
     {
         $cart = $event->getCart();
         $orderItem = $event->getOrderItem();

--- a/Classes/EventListener/Order/Create/PersistOrder/Taxes.php
+++ b/Classes/EventListener/Order/Create/PersistOrder/Taxes.php
@@ -15,7 +15,7 @@ use Extcode\Cart\Domain\Model\Order\Item as OrderItem;
 use Extcode\Cart\Domain\Model\Order\Tax as OrderTax;
 use Extcode\Cart\Domain\Repository\Order\ItemRepository;
 use Extcode\Cart\Domain\Repository\Order\TaxRepository;
-use Extcode\Cart\Event\Order\PersistOrderEventInterface;
+use Extcode\Cart\Event\Order\PersistOrderEvent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
@@ -27,7 +27,7 @@ class Taxes
         private readonly TaxRepository $taxRepository
     ) {}
 
-    public function __invoke(PersistOrderEventInterface $event): void
+    public function __invoke(PersistOrderEvent $event): void
     {
         $orderItem = $event->getOrderItem();
 
@@ -39,7 +39,7 @@ class Taxes
     }
 
     protected function addTaxToRepositoryAndItem(
-        PersistOrderEventInterface $event,
+        PersistOrderEvent $event,
         OrderItem $orderItem,
         string $typeOfTax
     ): OrderItem {

--- a/Classes/EventListener/Order/Finish/ClearCart.php
+++ b/Classes/EventListener/Order/Finish/ClearCart.php
@@ -13,7 +13,7 @@ namespace Extcode\Cart\EventListener\Order\Finish;
 
 use Extcode\Cart\Domain\Model\Order\BillingAddress;
 use Extcode\Cart\Domain\Model\Order\ShippingAddress;
-use Extcode\Cart\Event\Order\EventInterface;
+use Extcode\Cart\Event\Order\FinishEvent;
 use Extcode\Cart\Service\PaymentMethodsServiceInterface;
 use Extcode\Cart\Service\SessionHandler;
 use Extcode\Cart\Utility\CartUtility;
@@ -27,7 +27,7 @@ class ClearCart
         protected readonly SessionHandler $sessionHandler
     ) {}
 
-    public function __invoke(EventInterface $event): void
+    public function __invoke(FinishEvent $event): void
     {
         $cart = $event->getCart();
         $settings = $event->getSettings();

--- a/Classes/EventListener/Order/Finish/Email.php
+++ b/Classes/EventListener/Order/Finish/Email.php
@@ -12,7 +12,7 @@ namespace Extcode\Cart\EventListener\Order\Finish;
  */
 use Extcode\Cart\Domain\Model\Cart\Cart;
 use Extcode\Cart\Domain\Model\Order\Item;
-use Extcode\Cart\Event\Order\EventInterface;
+use Extcode\Cart\Event\Order\FinishEvent;
 use Extcode\Cart\Service\MailHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -20,7 +20,7 @@ class Email
 {
     protected Cart $cart;
 
-    public function __invoke(EventInterface $event): void
+    public function __invoke(FinishEvent $event): void
     {
         $this->cart = $event->getCart();
         $orderItem = $event->getOrderItem();


### PR DESCRIPTION
Replace the used EventInterfaces by the
really used specific Events in the `__invoke()`
method of Events where it's suitable.

In the next step the superfluous interfaces can
be removed. Furthermore can the `Services.yaml`
be shortened by using the #AsEventListener
attribute.