### PR TITLE
[DOCS] Move section to tutorials

### DIFF
--- a/Documentation/Administrator/Configuration/Email/Index.rst
+++ b/Documentation/Administrator/Configuration/Email/Index.rst
@@ -11,4 +11,3 @@ Email
    EmailAddresses/Index
    EmailAttachments/Index
    EMailContent/Index
-   OverwriteEmailTemplates/Index

--- a/Documentation/Tutorials/Index.rst
+++ b/Documentation/Tutorials/Index.rst
@@ -25,10 +25,16 @@ Tutorials
 
         A possible setup for routing in multistep checkout
 
+    ..  card:: :ref:`Overwrite email templates <overwrite-email-templates>`
+
+        Use own templates in the emails which are sent by EXT:cart.
+
 .. toctree::
    :maxdepth: 1
    :titlesonly:
+   :hidden:
 
    MiniCart/Index
    PrefillAddress/Index
    RoutingMultistepCheckout/Index
+   OverwriteEmailTemplates/Index

--- a/Documentation/Tutorials/OverwriteEmailTemplates/Index.rst
+++ b/Documentation/Tutorials/OverwriteEmailTemplates/Index.rst
@@ -1,4 +1,6 @@
-.. include:: ../../../../Includes.rst.txt
+.. include:: ../../Includes.rst.txt
+
+.. _overwrite-email-templates:
 
 =========================
 Overwrite email templates

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
                interlink-shortcode="extcode/cart"
     />
     <project title="Cart"
-             release="9.0.0"
-             version="9.0"
+             release="9.1.0"
+             version="9.1"
              copyright="2018 - 2024"
     />
     <inventory id="t3tsref" url="https://docs.typo3.org/typo3cms/TyposcriptReference/"/>


### PR DESCRIPTION
The section about overwriting email templates
is now placed within the tutorial section which
fits better than having this content within
the section for configuration.