### PR TITLE
Update documentation to zone-based configuration for payments and shippings

### DIFF
--- a/Documentation/Administrator/Configuration/PaymentMethods/Index.rst
+++ b/Documentation/Administrator/Configuration/PaymentMethods/Index.rst
@@ -200,11 +200,6 @@ Zone configuration
 plugin.tx_cart.payments.zones
 -----------------------------
 
-If no individual country configuration can be found, it is also possible to
-work with zones in the TypoScript.
-This saves a lot of configuration work if you want to deliver to many
-countries.
-
 The configuration of payment zones can be used to ease the configuration
 of payments for multiple countries. Their usage saves a lot of configuration
 work, if you want to deliver to many countries.
@@ -214,8 +209,8 @@ a dedicated country, the country configuration has precedence over the zone conf
 .. NOTE::
    * The system first searches for a suitable configuration in the list of country configurations.
    * The list of zone configurations is then looked through. The first matching configuration is used.
-   * Make sure to remove any (example) country-based payment configuration coming with the extension 
-     to avoid interference with the zone configuration otherwise explicitly wished.  
+   * The country-based payment configuration coming with the extension can interfere with your zone configuration for payments. 
+     Therefore, check if you need to remove the country-based configuration when using zones as shown below.
 
 .. code-block:: typoscript
    :caption: Can be set in e.g. EXT:sitepackage/Configuration/TypoScript/setup.typoscript

--- a/Documentation/Administrator/Configuration/PaymentMethods/Index.rst
+++ b/Documentation/Administrator/Configuration/PaymentMethods/Index.rst
@@ -8,7 +8,9 @@ Payment methods
 
 The payment methods are defined via TypoScript for each shopping cart.
 The standard template already includes a payment method (prepayment) as
-shown below.
+shown below. In case the payment method(s) for several countries shall
+be configured, please also check the possibility to use a 'zone' based 
+configuration. This reduces the amount of configuration necessary.
 
 With the definition `plugin.tx_cart.settings.allowedCountries` the output of
 the selector in the shopping cart is defined. The options can also be
@@ -203,14 +205,28 @@ work with zones in the TypoScript.
 This saves a lot of configuration work if you want to deliver to many
 countries.
 
+The configuration of payment zones can be used to ease the configuration
+of payments for multiple countries. Their usage saves a lot of configuration
+work, if you want to deliver to many countries.
+In case both country configuration as well as zone configuration are valid for
+a dedicated country, the country configuration has precedence over the zone configuration. 
+
+.. NOTE::
+   * The system first searches for a suitable configuration in the list of country configurations.
+   * The list of zone configurations is then looked through. The first matching configuration is used.
+   * Make sure to remove any (example) country-based payment configuration coming with the extension 
+     to avoid interference with the zone configuration otherwise explicitly wished.  
+
 .. code-block:: typoscript
    :caption: Can be set in e.g. EXT:sitepackage/Configuration/TypoScript/setup.typoscript
 
    plugin.tx_cart {
        payments {
+           // this removes any previous country based payment configuration
+           countries >       
            zones {
                1 {
-                   preset = 1
+                   preset = 2
                    countries = de,at,ch
                    options {
                        1 {
@@ -219,7 +235,14 @@ countries.
                            taxClassId = 1
                            status = open
                        }
-                   }
+                       2 {
+                           provider = PAYPAL
+                           title = Paypal
+                           extra = 0.50
+                           taxClassId = 1
+                           status = open
+                         }                       
+                    }
                }
            }
        }
@@ -236,10 +259,6 @@ countries.
    :Type: int
 
    List of countries for which this configuration is valid.
-
-.. NOTE::
-   * The system first searches for a suitable configuration in the list of country configurations.
-   * The list of zone configurations is then looked through. The first matching configuration is used.
 
 Deactivate payment methods
 ==========================

--- a/Documentation/Administrator/Configuration/ShippingMethods/Index.rst
+++ b/Documentation/Administrator/Configuration/ShippingMethods/Index.rst
@@ -221,8 +221,8 @@ a dedicated country, the country configuration has precedence over the zone conf
 .. NOTE::
    * The system first searches for a suitable configuration in the list of country configurations.
    * The list of zone configurations is then looked through. The first matching configuration is used.
-   * Make sure to remove any (example) country-based shipping configuration coming with the extension
-     to avoid interference with the zone configuration otherwise explicitly wished.
+   * The country-based shipping configuration coming with the extension can interfere with your zone configuration for shippings. 
+     Therefore, check if you need to remove the country-based configuration when using zones as shown below.
 
 .. code-block:: typoscript
    :caption: Can be set in e.g. EXT:sitepackage/Configuration/TypoScript/setup.typoscript

--- a/Documentation/Administrator/Configuration/ShippingMethods/Index.rst
+++ b/Documentation/Administrator/Configuration/ShippingMethods/Index.rst
@@ -8,7 +8,9 @@ Shipping methods
 
 The shipping methods are defined via TypoScript for each shopping cart.
 The standard template already comes with a shipping method (standard)
-as shown below.
+as shown below. In case the shipping method(s) for several countries shall
+be configured, please also check the possibility to use a 'zone' based 
+configuration. This reduces the amount of configuration necessary. 
 
 With the definition `plugin.tx_cart.settings.allowedCountries` the output of
 the selector in the shopping cart is defined. The options can also be
@@ -210,32 +212,85 @@ Zone configuration
 plugin.tx_cart.shippings.zones
 ------------------------------
 
-If no individual country configuration can be found, it is also possible to
-work with zones in the TypoScript.
-This saves a lot of configuration work if you want to deliver to many
-countries.
+The configuration of shipping zones can be used to ease the configuration
+of shippings for multiple countries. Their usage saves a lot of configuration
+work, if you want to deliver to many countries.
+In case both country configuration as well as zone configuration are valid for
+a dedicated country, the country configuration has precedence over the zone configuration. 
+
+.. NOTE::
+   * The system first searches for a suitable configuration in the list of country configurations.
+   * The list of zone configurations is then looked through. The first matching configuration is used.
+   * Make sure to remove any (example) country-based shipping configuration coming with the extension
+     to avoid interference with the zone configuration otherwise explicitly wished.
 
 .. code-block:: typoscript
+   :caption: Can be set in e.g. EXT:sitepackage/Configuration/TypoScript/setup.typoscript
 
    plugin.tx_cart {
        shippings {
+           // this removes any previous country based shipping configuration
+           countries >
            zones {
                1 {
-                   preset = 1
-                   countries = de,at,ch
-                   options {
-                       1 {
-                           title = Standard
+                  preset = 1
+                  countries = de
+                  options {
+                        1 {
+                           title = Shipment Germany
+                           extra = by_price
+                           extra {
+                               1  {
+                                   value = 0.00
+                                   extra = 3.70
+                                  }
+                               2  {
+                                   value = 100.00
+                                   extra = 0.00
+                                  }
+                                 }
+                               taxClassId = 1
+                               status = open
+                          }
+                        2 {
+                           title = Collect at shop
                            extra = 0.00
                            taxClassId = 1
                            status = open
-                       }
-                   }
-               }
+                          }
+                     }
+                 }
+               2 {
+                  preset = 1
+                  countries = at,ch
+                  options {
+                        1 {
+                           title = International Shipment
+                           extra = by_price
+                           extra {
+                               1  {
+                                   value = 0.00
+                                   extra = 5.90
+                                  }
+                               2  {
+                                   value = 100.00
+                                   extra = 0.00
+                                  }
+                                }
+                           taxClassId = 1
+                           status = open
+                          }
+                        2 {
+                           title = Collect at shop
+                           extra = 0.00
+                           taxClassId = 1
+                           status = open
+                          }
+                      }
+                  }
+               }                          
            }
        }
-   }
-
 |
 
 .. confval:: shippings.zones.<n>
@@ -249,10 +304,6 @@ countries.
    :Type: array
 
    List of countries for which this configuration is valid.
-
-.. NOTE::
-   * The system first searches for a suitable configuration in the list of country configurations.
-   * The list of zone configurations is then looked through. The first matching configuration is used.
 
 Deactivate shipping methods
 ===========================


### PR DESCRIPTION
Slightly enhancing the documentation for zone-based configuration for payments and shippings. Beside enhancing the example a hint has been added that the country-based configuration for payments and shippings can interfere with a zone-based configuration provided by the integrator.

Fixes: #591 