### PR TITLE
[BUGFIX] Adapt widget configuration to interface

### DIFF
--- a/Configuration/Backend/Widgets/OrdersPerDayWidget.php
+++ b/Configuration/Backend/Widgets/OrdersPerDayWidget.php
@@ -22,7 +22,6 @@ return function (ContainerConfigurator $configurator) {
             'title' => 'LLL:EXT:cart/Resources/Private/Language/locallang_be.xlf:dashboard.widgets.orders_per_day.title',
             'description' => 'LLL:EXT:cart/Resources/Private/Language/locallang_be.xlf:dashboard.widgets.orders_per_day.description',
             'iconIdentifier' => 'content-widget-chart-bar',
-            'additionalCssClasses' => 'dashboard-item--chart',
             'height' => 'medium',
             'width' => 'medium',
         ]);

--- a/Configuration/Backend/Widgets/TurnoverPerDayWidget.php
+++ b/Configuration/Backend/Widgets/TurnoverPerDayWidget.php
@@ -22,7 +22,6 @@ return function (ContainerConfigurator $configurator) {
             'title' => 'LLL:EXT:cart/Resources/Private/Language/locallang_be.xlf:dashboard.widgets.turnover_per_day.title',
             'description' => 'LLL:EXT:cart/Resources/Private/Language/locallang_be.xlf:dashboard.widgets.turnover_per_day.description',
             'iconIdentifier' => 'content-widget-chart-bar',
-            'additionalCssClasses' => 'dashboard-item--chart',
             'height' => 'medium',
             'width' => 'medium',
         ]);


### PR DESCRIPTION
The change https://review.typo3.org/c/Packages/TYPO3.CMS/+/89562 removed the property `additionalCssClasses` from
the `WidgetConfiguration` which results in an
error when setting this as argument in the
configuration.

This argument was according to the commit message
never used which means removing it does not
result in any changes.

Resolves: #673