### PR TITLE
[TASK] Use late static bindings to access AJAX_CART_TYPE_NUM from ext…

### DIFF
--- a/Classes/Controller/Cart/ProductController.php
+++ b/Classes/Controller/Cart/ProductController.php
@@ -104,7 +104,7 @@ class ProductController extends ActionController
         );
 
         $pageType = $GLOBALS['TYPO3_REQUEST']->getAttribute('routing')->getPageType();
-        if ($pageType === self::AJAX_CART_TYPE_NUM) {
+        if ($pageType === static::AJAX_CART_TYPE_NUM) {
             $productsChanged = $this->getChangedProducts($cartProducts);
 
             $response = [


### PR DESCRIPTION
AJAX_CART_TYPE_NUM sets the typeNum to 2278001. For cases where two different carts are needed, another typeNum has to be registered. To accomplish that, one can extend the ProductController just to define another AJAX_CART_TYPE_NUM and use the original methods. But that only works, if the comparison in line 107 (v10) does not read self::AJAX_CART_TYPE_NUM but static::AJAX_CART_TYPE_NUM

Resolves: #705