### PR TITLE
FIX: PHP warning in BE module

### DIFF
--- a/Classes/Controller/Backend/Order/OrderController.php
+++ b/Classes/Controller/Backend/Order/OrderController.php
@@ -69,7 +69,7 @@ class OrderController extends ActionController
         $this->moduleTemplate->assign('settings', $this->settings);
         $this->moduleTemplate->assign('searchArguments', $this->searchArguments);
 
-        $itemsPerPage = is_numeric($this->settings['itemsPerPage']) ? (int)$this->settings['itemsPerPage'] : 20;
+        $itemsPerPage = (int)($this->settings['itemsPerPage'] ?? 20);
 
         $orderItems = $this->itemRepository->findAll($this->searchArguments);
         $arrayPaginator = new QueryResultPaginator(


### PR DESCRIPTION
Core: Error handler (BE): PHP Warning: Undefined array key itemsPerPage in EXT:cart/Classes/Controller/Backend/Order/OrderController.php line 72