### PR TITLE
Prevent undefined array key "format" in CurrencyViewHelper.php

### DIFF
--- a/Classes/ViewHelpers/Format/CurrencyViewHelper.php
+++ b/Classes/ViewHelpers/Format/CurrencyViewHelper.php
@@ -102,7 +102,7 @@ class CurrencyViewHelper extends AbstractViewHelper
 
         $settings = $this->templateVariableContainer->get('settings');
 
-        if ($settings && $settings['format'] && $settings['format']['currency']) {
+        if (isset($settings['format']['currency'])) {
             $currencyFormat = $settings['format']['currency'];
 
             if (!isset($currencySign) && isset($currencyFormat['currencySign'])) {


### PR DESCRIPTION
When updating from 10.2.4 to 10.3.0 this warning occurred in the cart backend module on folders with orders.

Same as #556.

PHP Warning: Undefined array key "format" in /var/www/typo3/vendor/extcode/cart/Classes/ViewHelpers/Format/CurrencyViewHelper.php line 105