### PR TITLE
[BUGFIX] Use stable nix channel nixos-25.11 in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,7 +122,7 @@ jobs:
 
       - uses: cachix/install-nix-action@v17
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          nix_path: nixpkgs=channel:nixos-25.05
 
       - name: Run Unit Tests PHP8.1
         run: nix-shell --pure --run project-test-unit


### PR DESCRIPTION
In nixos-unstable the support for PHP 8.1 was removed.