### PR TITLE
[BUGFIX] Missing flexform fields in cart plugin content elements

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -37,11 +37,17 @@ call_user_func(function () {
 
         $flexFormPath = 'EXT:cart/Configuration/FlexForms/' . $pluginName . 'Plugin.xml';
         if (file_exists(GeneralUtility::getFileAbsFileName($flexFormPath))) {
-            $GLOBALS['TCA']['tt_content']['types'][$pluginSignature]['showitem'] = 'pi_flexform';
-
             ExtensionManagementUtility::addPiFlexFormValue(
+                '*',
+                'FILE:' . $flexFormPath,
+                $pluginSignature
+            );
+            // Add the FlexForm to the show item list
+            ExtensionManagementUtility::addToAllTCAtypes(
+                'tt_content',
+                '--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.plugin, pi_flexform',
                 $pluginSignature,
-                'FILE:' . $flexFormPath
+                'after:palette:headers'
             );
         }
     }


### PR DESCRIPTION
See the issue: https://github.com/extcode/cart/issues/658
This is Updated PR of: https://github.com/extcode/cart/pull/671