### PR TITLE
[BUGFIX] Dependency Injection via Services.php

### DIFF
--- a/Classes/Domain/Model/Cart/Cart.php
+++ b/Classes/Domain/Model/Cart/Cart.php
@@ -11,7 +11,7 @@ namespace Extcode\Cart\Domain\Model\Cart;
  * LICENSE file that was distributed with this source code.
  */
 
-use Extcode\Cart\Configuration\Loader\CurrencyTranslationLoaderInterface;
+use Extcode\Cart\Service\CurrencyTranslationServiceInterface;
 use InvalidArgumentException;
 use LogicException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -71,7 +71,7 @@ class Cart implements AdditionalDataInterface
 
     protected string $shippingCountry = '';
 
-    private ?CurrencyTranslationLoaderInterface $currencyTranslationLoader = null;
+    private ?CurrencyTranslationServiceInterface $currencyTranslationLoader = null;
 
     public function __construct(
         protected array $taxClasses,
@@ -80,7 +80,7 @@ class Cart implements AdditionalDataInterface
         protected string $currencySign = '€',
         protected float $currencyTranslation = 1.00
     ) {
-        $this->currencyTranslationLoader = GeneralUtility::makeInstance(CurrencyTranslationLoaderInterface::class);
+        $this->currencyTranslationLoader = GeneralUtility::makeInstance(CurrencyTranslationServiceInterface::class);
 
         $this->net = 0.0;
         $this->gross = 0.0;
@@ -983,7 +983,7 @@ class Cart implements AdditionalDataInterface
     public function translatePrice(?float $price = null): ?float
     {
         if (is_null($this->currencyTranslationLoader)) {
-            $this->currencyTranslationLoader = GeneralUtility::makeInstance(CurrencyTranslationLoaderInterface::class);
+            $this->currencyTranslationLoader = GeneralUtility::makeInstance(CurrencyTranslationServiceInterface::class);
         }
 
         return $this->currencyTranslationLoader->translatePrice($this->getCurrencyTranslation(), $price);

--- a/Classes/Service/CurrencyTranslationService.php
+++ b/Classes/Service/CurrencyTranslationService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Extcode\Cart\Configuration\Loader;
+namespace Extcode\Cart\Service;
 
 /*
  * This file is part of the package extcode/cart.
@@ -11,7 +11,7 @@ namespace Extcode\Cart\Configuration\Loader;
  * LICENSE file that was distributed with this source code.
  */
 
-class CurrencyTranslationLoader implements CurrencyTranslationLoaderInterface
+class CurrencyTranslationService implements CurrencyTranslationServiceInterface
 {
     public function translatePrice(float $factor, ?float $price = null): ?float
     {

--- a/Classes/Service/CurrencyTranslationServiceInterface.php
+++ b/Classes/Service/CurrencyTranslationServiceInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Extcode\Cart\Configuration\Loader;
+namespace Extcode\Cart\Service;
 
 /*
  * This file is part of the package extcode/cart.
@@ -14,7 +14,7 @@ namespace Extcode\Cart\Configuration\Loader;
 /**
  * @internal This class is marked internal and is not considered part of the public API. The interface will change in the next major version (v12.0.0).
  */
-interface CurrencyTranslationLoaderInterface
+interface CurrencyTranslationServiceInterface
 {
     public function translatePrice(float $factor, ?float $price = null): ?float;
 }

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Extcode\Cart\Configuration;
 
 use Extcode\Cart\Hooks\ItemsProcFunc;
+use Extcode\Cart\Service\CurrencyTranslationService;
+use Extcode\Cart\Service\CurrencyTranslationServiceInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use TYPO3\CMS\Dashboard\Widgets\BarChartWidget;
@@ -23,17 +25,43 @@ return static function (ContainerConfigurator $containerConfigurator, ContainerB
         $containerConfigurator->import('Backend/Widgets/TurnoverPerDayWidget.php');
     }
 
+    $services = $containerConfigurator
+        ->services()
+        ->defaults()
+        ->autowire()
+        ->autoconfigure()
+    ;
+
+    $services
+        ->load(
+            'Extcode\\Cart\\',
+            '../Classes/*'
+        )
+        ->exclude(
+            [
+                '../Classes/Widgets/*',
+                '../Classes/Command/*',
+            ]
+        )
+    ;
+
+    $services
+        ->alias(
+            CurrencyTranslationServiceInterface::class,
+            CurrencyTranslationService::class
+        )
+        ->public()
+    ;
+
     if (
         $containerBuilder->hasDefinition(ConfigurationManager::class)
         && $containerBuilder->hasDefinition(FormPersistenceManager::class)
     ) {
-        $services = $containerConfigurator->services();
-
         $services->set(ItemsProcFunc::class)
             ->public()
         ;
     }
 
-    $containerConfigurator->import('Services/Configuration.php');
+    $containerConfigurator->import('Services/ConfigurationLoader.php');
     $containerConfigurator->import('Services/ConsoleCommands.php');
 };

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -4,12 +4,6 @@ services:
     autoconfigure: true
     public: false
 
-  Extcode\Cart\:
-    resource: '../Classes/*'
-    exclude:
-      - '../Classes/Widgets/*'
-      - '../Classes/Command/*'
-
   Extcode\Cart\EventListener\Template\Components\ModifyButtonBar:
     tags:
       - name: event.listener

--- a/Configuration/Services/ConfigurationLoader.php
+++ b/Configuration/Services/ConfigurationLoader.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-use Extcode\Cart\Configuration\Loader\CurrencyTranslationLoader;
-use Extcode\Cart\Configuration\Loader\CurrencyTranslationLoaderInterface;
 use Extcode\Cart\Configuration\Loader\PaymentMethodsLoaderInterface;
 use Extcode\Cart\Configuration\Loader\ShippingMethodsLoaderInterface;
 use Extcode\Cart\Configuration\Loader\SiteSets\PaymentMethodsLoader as SiteSetsPaymentMethodsLoader;
@@ -19,13 +17,9 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator
         ->services()
-    ;
-
-    $services
-        ->alias(
-            CurrencyTranslationLoaderInterface::class,
-            CurrencyTranslationLoader::class
-        )
+        ->defaults()
+        ->autowire()
+        ->autoconfigure()
     ;
 
     $services
@@ -33,6 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             PaymentMethodsLoaderInterface::class,
             TypoScriptPaymentMethodsLoader::class
         )
+        ->public()
     ;
 
     $services
@@ -50,6 +45,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ShippingMethodsLoaderInterface::class,
             TypoScriptShippingMethodsLoader::class
         )
+        ->public()
     ;
 
     $services
@@ -72,6 +68,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             TaxClassLoaderInterface::class,
             TypoScriptTaxClassLoader::class
         )
+        ->public()
     ;
 
     $services

--- a/Documentation/Changelog/12.0/Breaking-756-AddSiteSetConfigurationLoader.rst
+++ b/Documentation/Changelog/12.0/Breaking-756-AddSiteSetConfigurationLoader.rst
@@ -15,7 +15,6 @@ moved to `Configuration/Loader`.
 
 The interfaces was moved form `Service` to `Configuration`:
 
-`Classes/Service/CurrencyTranslationServiceInterface.php` => `Classes/Configuration/Loader/CurrencyTranslationLoaderInterface.php`
 `Classes/Service/TaxClassServiceInterface.php` => `Classes/Configuration/Loader/TaxClassLoaderInterface.php`
 `Classes/Service/PaymentMethodsServiceInterface.php` => `Classes/Configuration/Loader/PaymentMethodsLoaderInterface.php`
 `Classes/Service/ShippingMethodsServiceInterface.php` => `Classes/Configuration/Loader/ShippingMethodsLoaderInterface.php`
@@ -23,7 +22,6 @@ The interfaces was moved form `Service` to `Configuration`:
 
 The classes was moved form `Service` to `Configuration` or `Configuration/TypoScript`:
 
-`Classes/Service/CurrencyTranslationService.php` => `Classes/Configuration/Loader/CurrencyTranslationLoader.php`
 `Classes/Service/PaymentMethodsFromTypoScriptService.php` => `Classes/Configuration/Loader/TypoScript/PaymentMethodsLoader.php`
 `Classes/Service/ShippingMethodsFromTypoScriptService.php` => `Classes/Configuration/Loader/TypoScript/ShippingMethodsLoader.php`
 `Classes/Service/SpecialOptionsFromTypoScriptService.php` => `Classes/Configuration/Loader/TypoScript/SpecialOptionsLoader.php`

--- a/Tests/Unit/Domain/Model/Cart/CartCouponFixTest.php
+++ b/Tests/Unit/Domain/Model/Cart/CartCouponFixTest.php
@@ -11,11 +11,11 @@ namespace Extcode\Cart\Tests\Unit\Domain\Model\Cart;
  * LICENSE file that was distributed with this source code.
  */
 
-use Extcode\Cart\Configuration\Loader\CurrencyTranslationLoader;
-use Extcode\Cart\Configuration\Loader\CurrencyTranslationLoaderInterface;
 use Extcode\Cart\Domain\Model\Cart\Cart;
 use Extcode\Cart\Domain\Model\Cart\CartCouponFix;
 use Extcode\Cart\Domain\Model\Cart\TaxClass;
+use Extcode\Cart\Service\CurrencyTranslationService;
+use Extcode\Cart\Service\CurrencyTranslationServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -240,8 +240,8 @@ class CartCouponFixTest extends UnitTestCase
     private function createCartMock(array $methods = ['getGross']): Cart|MockObject
     {
         GeneralUtility::addInstance(
-            CurrencyTranslationLoaderInterface::class,
-            new CurrencyTranslationLoader()
+            CurrencyTranslationServiceInterface::class,
+            new CurrencyTranslationService()
         );
 
         return $this->getMockBuilder(Cart::class)

--- a/Tests/Unit/Domain/Model/Cart/CartCouponPercentageTest.php
+++ b/Tests/Unit/Domain/Model/Cart/CartCouponPercentageTest.php
@@ -11,11 +11,11 @@ namespace Extcode\Cart\Tests\Unit\Domain\Model\Cart;
  * LICENSE file that was distributed with this source code.
  */
 
-use Extcode\Cart\Configuration\Loader\CurrencyTranslationLoader;
-use Extcode\Cart\Configuration\Loader\CurrencyTranslationLoaderInterface;
 use Extcode\Cart\Domain\Model\Cart\Cart;
 use Extcode\Cart\Domain\Model\Cart\CartCouponPercentage;
 use Extcode\Cart\Domain\Model\Cart\TaxClass;
+use Extcode\Cart\Service\CurrencyTranslationService;
+use Extcode\Cart\Service\CurrencyTranslationServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -270,8 +270,8 @@ class CartCouponPercentageTest extends UnitTestCase
     private function createCartMock(array $methods = ['getGross']): Cart|MockObject
     {
         GeneralUtility::addInstance(
-            CurrencyTranslationLoaderInterface::class,
-            new CurrencyTranslationLoader()
+            CurrencyTranslationServiceInterface::class,
+            new CurrencyTranslationService()
         );
 
         return $this->getMockBuilder(Cart::class)

--- a/Tests/Unit/Domain/Model/Cart/CartTest.php
+++ b/Tests/Unit/Domain/Model/Cart/CartTest.php
@@ -11,13 +11,13 @@ namespace Extcode\Cart\Tests\Unit\Domain\Model\Cart;
  * LICENSE file that was distributed with this source code.
  */
 
-use Extcode\Cart\Configuration\Loader\CurrencyTranslationLoader;
-use Extcode\Cart\Configuration\Loader\CurrencyTranslationLoaderInterface;
 use Extcode\Cart\Domain\Model\Cart\Cart;
 use Extcode\Cart\Domain\Model\Cart\CartCouponFix;
 use Extcode\Cart\Domain\Model\Cart\ProductFactory;
 use Extcode\Cart\Domain\Model\Cart\ProductFactoryInterface;
 use Extcode\Cart\Domain\Model\Cart\TaxClass;
+use Extcode\Cart\Service\CurrencyTranslationService;
+use Extcode\Cart\Service\CurrencyTranslationServiceInterface;
 use LogicException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -1315,8 +1315,8 @@ class CartTest extends UnitTestCase
         $couponGross = 10.00;
 
         GeneralUtility::addInstance(
-            CurrencyTranslationLoaderInterface::class,
-            new CurrencyTranslationLoader()
+            CurrencyTranslationServiceInterface::class,
+            new CurrencyTranslationService()
         );
         $cart = $this->getMockBuilder(Cart::class)
             ->onlyMethods(['getCouponGross', 'getCurrencyTranslation'])
@@ -1353,8 +1353,8 @@ class CartTest extends UnitTestCase
         $couponNet = $couponGross / 1.19;
 
         GeneralUtility::addInstance(
-            CurrencyTranslationLoaderInterface::class,
-            new CurrencyTranslationLoader()
+            CurrencyTranslationServiceInterface::class,
+            new CurrencyTranslationService()
         );
         $cart = $this->getMockBuilder(Cart::class)
             ->onlyMethods(['getCouponNet', 'getCurrencyTranslation'])
@@ -1402,8 +1402,8 @@ class CartTest extends UnitTestCase
     public function constructorSetsCurrencyCode(): void
     {
         GeneralUtility::addInstance(
-            CurrencyTranslationLoaderInterface::class,
-            new CurrencyTranslationLoader()
+            CurrencyTranslationServiceInterface::class,
+            new CurrencyTranslationService()
         );
         $cart = new Cart(
             $this->taxClasses,
@@ -1455,8 +1455,8 @@ class CartTest extends UnitTestCase
     public function constructorSetsCurrencySign(): void
     {
         GeneralUtility::addInstance(
-            CurrencyTranslationLoaderInterface::class,
-            new CurrencyTranslationLoader()
+            CurrencyTranslationServiceInterface::class,
+            new CurrencyTranslationService()
         );
         $cart = new Cart(
             $this->taxClasses,
@@ -1508,8 +1508,8 @@ class CartTest extends UnitTestCase
     public function constructorSetsCurrencyTranslation(): void
     {
         GeneralUtility::addInstance(
-            CurrencyTranslationLoaderInterface::class,
-            new CurrencyTranslationLoader()
+            CurrencyTranslationServiceInterface::class,
+            new CurrencyTranslationService()
         );
         $cart = new Cart(
             $this->taxClasses,
@@ -1603,8 +1603,8 @@ class CartTest extends UnitTestCase
     private function createCart(bool $isNetCart): Cart
     {
         GeneralUtility::addInstance(
-            CurrencyTranslationLoaderInterface::class,
-            new CurrencyTranslationLoader()
+            CurrencyTranslationServiceInterface::class,
+            new CurrencyTranslationService()
         );
 
         return new Cart($this->taxClasses, $isNetCart);

--- a/Tests/Unit/Domain/Model/Cart/ServiceTest.php
+++ b/Tests/Unit/Domain/Model/Cart/ServiceTest.php
@@ -11,12 +11,12 @@ namespace Extcode\Cart\Tests\Unit\Domain\Model\Cart;
  * LICENSE file that was distributed with this source code.
  */
 
-use Extcode\Cart\Configuration\Loader\CurrencyTranslationLoader;
-use Extcode\Cart\Configuration\Loader\CurrencyTranslationLoaderInterface;
 use Extcode\Cart\Domain\Model\Cart\Cart;
 use Extcode\Cart\Domain\Model\Cart\Product;
 use Extcode\Cart\Domain\Model\Cart\Service;
 use Extcode\Cart\Domain\Model\Cart\TaxClass;
+use Extcode\Cart\Service\CurrencyTranslationService;
+use Extcode\Cart\Service\CurrencyTranslationServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -471,8 +471,8 @@ class ServiceTest extends UnitTestCase
     private function createCartMock(array $methods = ['getGross']): Cart|MockObject
     {
         GeneralUtility::addInstance(
-            CurrencyTranslationLoaderInterface::class,
-            new CurrencyTranslationLoader()
+            CurrencyTranslationServiceInterface::class,
+            new CurrencyTranslationService()
         );
 
         return $this->getMockBuilder(Cart::class)


### PR DESCRIPTION
Rename CurrencyTranslationLoader to CurrencyTranslationService and move class back to Services because this isn't a Configuration Loader.